### PR TITLE
Add and expose a ReplayControl from the DataPipeline

### DIFF
--- a/modules/command-engine/core/src/test/scala/surge/internal/persistence/PersistentActorSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/persistence/PersistentActorSpec.scala
@@ -568,9 +568,6 @@ class PersistentActorSpec
       val testContext = TestContext.setupDefault
       import testContext._
 
-      probe.send(actor, ReceiveTimeout) // When uninitialized, the actor should ignore a ReceiveTimeout
-      probe.expectNoMessage()
-
       processIncrementCommand(actor, baseState, mockProducer)
 
       probe.watch(actor)

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommand.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommand.scala
@@ -2,18 +2,17 @@
 
 package surge.javadsl.command
 
+import java.util.concurrent.CompletionStage
+
 import akka.actor.ActorSystem
 import com.typesafe.config.{ Config, ConfigFactory }
-import play.api.libs.json.JsValue
 import surge.core
-import surge.core.{ command, SurgePartitionRouter }
+import surge.core.command
 import surge.core.command.SurgeCommandModel
 import surge.internal.commondsl.command.{ SurgeCommandBusinessLogic, SurgeRejectableCommandBusinessLogic }
 import surge.javadsl.common.{ HealthCheck, HealthCheckTrait }
-import surge.kafka.streams.AggregateStateStoreKafkaStreams
 import surge.metrics.Metric
 
-import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
@@ -52,9 +51,6 @@ private[javadsl] class SurgeCommandImpl[AggId, Agg, Command, +Rej, Evt](
     config: Config)
     extends command.SurgeCommandImpl[Agg, Command, Rej, Evt](actorSystem, businessLogic, config)
     with SurgeCommand[AggId, Agg, Command, Rej, Evt] {
-
-  override protected val actorRouter: SurgePartitionRouter = createPartitionRouter()
-  override protected val kafkaStreamsImpl: AggregateStateStoreKafkaStreams[JsValue] = createStateStore()
 
   import surge.javadsl.common.HealthCheck._
   def getHealthCheck: CompletionStage[HealthCheck] = {

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/SurgeCommand.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/SurgeCommand.scala
@@ -4,12 +4,10 @@ package surge.scaladsl.command
 
 import akka.actor.ActorSystem
 import com.typesafe.config.{ Config, ConfigFactory }
-import play.api.libs.json.JsValue
 import surge.core
-import surge.core.{ command, SurgePartitionRouter }
+import surge.core.command
 import surge.core.command.SurgeCommandModel
 import surge.internal.commondsl.command.{ SurgeCommandBusinessLogic, SurgeRejectableCommandBusinessLogic }
-import surge.kafka.streams.AggregateStateStoreKafkaStreams
 import surge.metrics.Metric
 import surge.scaladsl.common.HealthCheckTrait
 
@@ -46,9 +44,6 @@ private[scaladsl] class SurgeCommandImpl[AggId, Agg, Command, +Rej, Event](
     override val config: Config)
     extends command.SurgeCommandImpl[Agg, Command, Rej, Event](actorSystem, businessLogic, config)
     with SurgeCommand[AggId, Agg, Command, Rej, Event] {
-
-  override protected val actorRouter: SurgePartitionRouter = createPartitionRouter()
-  override protected val kafkaStreamsImpl: AggregateStateStoreKafkaStreams[JsValue] = createStateStore()
 
   def aggregateFor(aggregateId: AggId): AggregateRef[Agg, Command, Event] = {
     new AggregateRefImpl(aggIdToString(aggregateId), actorRouter.actorRegion, businessLogic.tracer)

--- a/modules/common/src/main/scala/surge/internal/streams/ManagedDataPipeline.scala
+++ b/modules/common/src/main/scala/surge/internal/streams/ManagedDataPipeline.scala
@@ -8,11 +8,12 @@ import com.typesafe.config.ConfigFactory
 import surge.metrics.Metrics
 import surge.streams.DataPipeline
 import surge.streams.DataPipeline.ReplayResult
+import surge.streams.replay.ReplayControl
 
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 
-private[surge] class ManagedDataPipeline(underlyingManager: KafkaStreamManager[_, _], metrics: Metrics) extends DataPipeline {
+private[surge] class ManagedDataPipeline[Key, Value](underlyingManager: KafkaStreamManager[Key, Value], metrics: Metrics) extends DataPipeline {
   private val kafkaConsumerMetricsName: String = s"kafka-consumer-metrics-${UUID.randomUUID()}"
   private val config = ConfigFactory.load()
   private val enableMetrics = config.getBoolean("surge.kafka-event-source.enable-kafka-metrics")
@@ -31,4 +32,6 @@ private[surge] class ManagedDataPipeline(underlyingManager: KafkaStreamManager[_
   override def replay(): Future[ReplayResult] = {
     underlyingManager.replay()
   }
+
+  override def getReplayControl: ReplayControl = underlyingManager.getReplayControl
 }

--- a/modules/common/src/main/scala/surge/streams/DataPipeline.scala
+++ b/modules/common/src/main/scala/surge/streams/DataPipeline.scala
@@ -5,6 +5,7 @@ package surge.streams
 import java.util.concurrent.CompletionStage
 
 import surge.streams.DataPipeline.ReplayResult
+import surge.streams.replay.ReplayControl
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
@@ -16,6 +17,8 @@ trait DataPipeline {
   def replayWithCompletionStage(): CompletionStage[ReplayResult] = {
     replay().toJava
   }
+
+  def getReplayControl: ReplayControl
 }
 
 object DataPipeline {
@@ -29,4 +32,5 @@ class TypedDataPipeline[Type](dataPipeline: DataPipeline) extends DataPipeline {
   override def start(): Unit = dataPipeline.start()
   override def stop(): Unit = dataPipeline.stop()
   override def replay(): Future[ReplayResult] = dataPipeline.replay()
+  override def getReplayControl: ReplayControl = dataPipeline.getReplayControl
 }

--- a/modules/common/src/main/scala/surge/streams/DataSource.scala
+++ b/modules/common/src/main/scala/surge/streams/DataSource.scala
@@ -20,8 +20,8 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 trait DataSource[Key, Value] {
-  private val defaultReplayStrategy = new NoOpEventReplayStrategy[Key, Value]
-  def replayStrategy: EventReplayStrategy[Key, Value] = defaultReplayStrategy
+  private val defaultReplayStrategy = new NoOpEventReplayStrategy
+  def replayStrategy: EventReplayStrategy = defaultReplayStrategy
   def replaySettings: EventReplaySettings = DefaultEventReplaySettings
 }
 
@@ -66,7 +66,15 @@ trait KafkaDataSource[Key, Value] extends DataSource[Key, Value] {
       case _ =>
         new ManualOffsetManagementSubscriptionProvider[Key, Value](topicName, subscription, consumerSettings, sink, offsetManager)
     }
-    new KafkaStreamManager[Key, Value](topicName, consumerSettings, subscriptionProvider, replayStrategy, replaySettings, tracer)
+    new KafkaStreamManager[Key, Value](
+      topicName = topicName,
+      consumerSettings = consumerSettings,
+      subscriptionProvider = subscriptionProvider,
+      keyDeserializer = keyDeserializer,
+      valueDeserializer = valueDeserializer,
+      replayStrategy = replayStrategy,
+      replaySettings = replaySettings,
+      tracer = tracer)
   }
 
   private[streams] def to(consumerSettings: ConsumerSettings[Key, Value])(sink: DataHandler[Key, Value], autoStart: Boolean): DataPipeline = {

--- a/modules/common/src/main/scala/surge/streams/replay/EventReplayStrategy.scala
+++ b/modules/common/src/main/scala/surge/streams/replay/EventReplayStrategy.scala
@@ -6,16 +6,28 @@ import java.util.concurrent.TimeUnit
 
 import akka.Done
 import com.typesafe.config.ConfigFactory
-import surge.internal.utils.Logging
+import org.slf4j.LoggerFactory
 import surge.streams.DataHandler
 
 import scala.concurrent.Future
 import scala.concurrent.duration.{ FiniteDuration, _ }
 
-trait EventReplayStrategy[Key, Value] {
+case class ReplayControlContext[Key, Value](keyDeserializer: Array[Byte] => Key, valueDeserializer: Array[Byte] => Value, dataHandler: DataHandler[Key, Value])
+trait EventReplayStrategy {
   def preReplay: () => Future[Any]
   def postReplay: () => Unit
-  def replay(consumerGroup: String, partitions: Iterable[Int], replayFlow: DataHandler[Key, Value]): Future[Done]
+  def createReplayController[Key, Value](context: ReplayControlContext[Key, Value]): ReplayControl
+}
+
+/**
+ * The ReplayControl is a low level control object for performing replay. By default it has a preReplay, postReplay, and fullReplay function. The ReplayControl
+ * itself does not coordinate stopping any currently running consumers - it simply provides a way to access various replay functionality for callers who need
+ * replay-like functionality outside of a typical full/coordinated replay.
+ */
+trait ReplayControl {
+  def preReplay: () => Future[Any]
+  def postReplay: () => Unit
+  def fullReplay(consumerGroup: String, partitions: Iterable[Int]): Future[Done]
 }
 
 object DefaultEventReplaySettings extends EventReplaySettings {
@@ -23,10 +35,17 @@ object DefaultEventReplaySettings extends EventReplaySettings {
   override val entireReplayTimeout: FiniteDuration = config.getDuration("kafka.streams.replay.entire-process-timeout", TimeUnit.MILLISECONDS).milliseconds
 }
 
-class NoOpEventReplayStrategy[Key, Value] extends EventReplayStrategy[Key, Value] with Logging {
+class NoOpEventReplayStrategy extends EventReplayStrategy {
   override def preReplay: () => Future[Any] = () => Future.successful(true)
   override def postReplay: () => Unit = () => {}
-  override def replay(consumerGroup: String, partitions: Iterable[Int], replayFlow: DataHandler[Key, Value]): Future[Done] = {
+
+  override def createReplayController[Key, Value](context: ReplayControlContext[Key, Value]): NoOpEventReplayControl =
+    new NoOpEventReplayControl(preReplay, postReplay)
+}
+class NoOpEventReplayControl(override val preReplay: () => Future[Any] = () => Future.successful(true), override val postReplay: () => Unit = () => {})
+    extends ReplayControl {
+  private val log = LoggerFactory.getLogger(getClass)
+  override def fullReplay(consumerGroup: String, partitions: Iterable[Int]): Future[Done] = {
     log.warn("Event Replay has been used with the default NoOps implementation, please refer to the docs to properly chose your replay strategy")
     Future.successful(Done)
   }

--- a/modules/common/src/test/scala/surge/internal/streams/StreamManagerSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/streams/StreamManagerSpec.scala
@@ -60,7 +60,7 @@ class StreamManagerSpec
       kafkaBrokers: String,
       groupId: String,
       businessLogic: (String, Array[Byte]) => Future[_],
-      replayStrategy: EventReplayStrategy[String, Array[Byte]] = new NoOpEventReplayStrategy,
+      replayStrategy: EventReplayStrategy = new NoOpEventReplayStrategy,
       replaySettings: EventReplaySettings = DefaultEventReplaySettings): KafkaStreamManager[String, Array[Byte]] = {
     val consumerSettings = AkkaKafkaConsumer.consumerSettings[String, Array[Byte]](system, groupId).withBootstrapServers(kafkaBrokers)
 
@@ -72,7 +72,15 @@ class StreamManagerSpec
         FlowConverter.flowFor[String, Array[Byte], Meta](tupleFlow, partitionBy, new DefaultDataSinkExceptionHandler, parallelism)
     }
     val subscriptionProvider = new KafkaOffsetManagementSubscriptionProvider(topic.name, Subscriptions.topics(topic.name), consumerSettings, businessFlow)
-    new KafkaStreamManager(topic.name, consumerSettings, subscriptionProvider, replayStrategy, replaySettings, NoopTracerFactory.create())
+    new KafkaStreamManager(
+      topic.name,
+      consumerSettings,
+      subscriptionProvider,
+      stringDeserializer,
+      byteArrayDeserializer,
+      replayStrategy,
+      replaySettings,
+      NoopTracerFactory.create())
   }
 
   "StreamManager" should {

--- a/modules/common/src/test/scala/surge/streams/sink/TestEventSource.scala
+++ b/modules/common/src/test/scala/surge/streams/sink/TestEventSource.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ Keep, Sink }
 import akka.stream.testkit.TestPublisher
 import akka.stream.testkit.scaladsl.TestSource
+import surge.streams.replay.{ NoOpEventReplayControl, ReplayControl }
 import surge.streams.{ DataPipeline, EventHandler, EventPlusStreamMeta, EventSource }
 
 import scala.concurrent.Future
@@ -29,4 +30,6 @@ class TestDataPipeline[Event](probe: TestPublisher.Probe[EventPlusStreamMeta[Str
     probe.sendNext(eventPlusStreamMeta)
     this
   }
+
+  override def getReplayControl: ReplayControl = new NoOpEventReplayControl()
 }

--- a/modules/rabbit-support/src/main/scala/surge/rabbit/RabbitDataPipeline.scala
+++ b/modules/rabbit-support/src/main/scala/surge/rabbit/RabbitDataPipeline.scala
@@ -9,6 +9,7 @@ import akka.stream.scaladsl.{ Keep, RestartSource, Sink, Source }
 import akka.stream.{ KillSwitch, KillSwitches, Materializer }
 import surge.streams.DataPipeline
 import surge.streams.DataPipeline.ReplaySuccessfullyStarted
+import surge.streams.replay.{ NoOpEventReplayControl, ReplayControl }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -39,4 +40,6 @@ private[rabbit] class RabbitDataPipeline(source: Source[CommittableReadResult, N
   }
 
   override def replay(): Future[DataPipeline.ReplayResult] = Future.successful(ReplaySuccessfullyStarted())
+
+  override def getReplayControl: ReplayControl = new NoOpEventReplayControl()
 }


### PR DESCRIPTION
Adds and exposes a ReplayControl from the DataPipeline which can be used for more fine grained replays downstream.

Full replays still go through the ReplayCoordinator in order to coordinate the shutdown of any currently running consumers.  The ReplayControl can be extended by various replay strategies so that they can layer on other more specific replay capabilities depending on what the replay strategy can support - for example replaying on a particular aggregate id or events only from a particular point in time onwards.