### PR TITLE
Add codecov integration

### DIFF
--- a/.github/workflows/surge-ci.yml
+++ b/.github/workflows/surge-ci.yml
@@ -22,3 +22,4 @@ jobs:
         if: 'always()'
         with:
           report_paths: 'target/test-reports/*.xml'
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/surge-main.yml
+++ b/.github/workflows/surge-main.yml
@@ -22,3 +22,4 @@ jobs:
         if: 'always()'
         with:
           report_paths: 'target/test-reports/*.xml'
+      - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Publishes coverage information to codecov so that we can track code coverage over time.