### PR TITLE
Use CODECOV token so main branch code coverage can be uploaded properly

### DIFF
--- a/.github/workflows/surge-ci.yml
+++ b/.github/workflows/surge-ci.yml
@@ -23,3 +23,5 @@ jobs:
         with:
           report_paths: 'target/test-reports/*.xml'
       - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/surge-main.yml
+++ b/.github/workflows/surge-main.yml
@@ -23,3 +23,5 @@ jobs:
         with:
           report_paths: 'target/test-reports/*.xml'
       - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/modules/common/src/test/scala/surge/internal/streams/KafkaSubscriptionProviderSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/streams/KafkaSubscriptionProviderSpec.scala
@@ -13,6 +13,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.{ Deserializer, Serializer }
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpecLike
 import surge.internal.akka.kafka.AkkaKafkaConsumer
 import surge.internal.akka.streams.FlowConverter
@@ -28,6 +29,8 @@ class KafkaSubscriptionProviderSpec extends TestKit(ActorSystem("StreamManagerSp
   private implicit val stringSer: Serializer[String] = DefaultSerdes.stringSerde.serializer()
   private implicit val stringDeserializer: Deserializer[String] = DefaultSerdes.stringSerde.deserializer()
   private implicit val byteArrayDeserializer: Deserializer[Array[Byte]] = DefaultSerdes.byteArraySerde.deserializer()
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(100, Millis))
 
   private class InMemoryOffsetManager() extends OffsetManager {
     private val offsetMappings: scala.collection.mutable.Map[TopicPartition, Long] = scala.collection.mutable.Map.empty


### PR DESCRIPTION
The CI branch works without the `CODECOV_TOKEN` but the `main` branch hits the following error in the codecov step:
```
{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
65
```
Adding the token to main should fix this there, but I'm also including it in the CI build for consistency.

Additionally addresses a couple of unit tests I noticed were a bit flaky.