### PR TITLE
change the command API so as to not lump aggregate and event serialization into a single trait/argument

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/command/SurgeCommandModel.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/command/SurgeCommandModel.scala
@@ -4,7 +4,7 @@ package surge.core.command
 
 import io.opentracing.Tracer
 import surge.core.commondsl.{ SurgeCommandBusinessLogicTrait, SurgeRejectableCommandBusinessLogicTrait }
-import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting, SurgeWriteFormatting }
+import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting }
 import surge.internal.SurgeModel
 import surge.internal.domain.AggregateProcessingModel
 import surge.internal.kafka.SurgeKafkaConfig
@@ -29,8 +29,9 @@ private[surge] object SurgeCommandModel {
       aggregateName = businessLogic.aggregateName,
       kafka = businessLogic.kafkaConfig,
       model = businessLogic.commandModel.toCore,
-      writeFormatting = businessLogic.writeFormatting,
+      aggregateWriteFormatting = businessLogic.aggregateWriteFormatting,
       aggregateReadFormatting = businessLogic.aggregateReadFormatting,
+      eventWriteFormatting = businessLogic.eventWriteFormatting,
       aggregateValidator = businessLogic.aggregateValidatorLambda,
       metrics = businessLogic.metrics,
       tracer = businessLogic.tracer)
@@ -41,8 +42,9 @@ private[surge] object SurgeCommandModel {
       aggregateName = businessLogic.aggregateName,
       kafka = businessLogic.kafkaConfig,
       model = businessLogic.commandModel.toCore,
-      writeFormatting = businessLogic.writeFormatting,
+      aggregateWriteFormatting = businessLogic.aggregateWriteFormatting,
       aggregateReadFormatting = businessLogic.aggregateReadFormatting,
+      eventWriteFormatting = businessLogic.eventWriteFormatting,
       aggregateValidator = businessLogic.aggregateValidatorLambda,
       metrics = businessLogic.metrics,
       tracer = businessLogic.tracer)
@@ -53,12 +55,12 @@ private[surge] case class SurgeCommandModel[Agg, Command, +Rej, Event](
     override val aggregateName: String,
     override val kafka: SurgeCommandKafkaConfig,
     override val model: AggregateProcessingModel[Agg, Command, Rej, Event],
-    override val aggregateReadFormatting: SurgeAggregateReadFormatting[Agg],
-    writeFormatting: SurgeWriteFormatting[Agg, Event],
+    override val aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg],
     override val aggregateValidator: (String, Array[Byte], Option[Array[Byte]]) => Boolean,
     override val metrics: Metrics,
-    override val tracer: Tracer)
+    override val tracer: Tracer,
+    override val aggregateReadFormatting: SurgeAggregateReadFormatting[Agg],
+    eventWriteFormatting: SurgeEventWriteFormatting[Event])
     extends SurgeModel[Agg, Command, Rej, Event] {
-  override val aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg] = writeFormatting
-  override val eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[Event]] = Some(writeFormatting)
+  override val eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[Event]] = Some(eventWriteFormatting)
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeCommandBusinessLogic.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeCommandBusinessLogic.scala
@@ -3,18 +3,16 @@
 package surge.core.commondsl
 
 import surge.core.command.{ AggregateCommandModelCoreTrait, SurgeCommandKafkaConfig }
-import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting, SurgeWriteFormatting }
+import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting }
 import surge.kafka.KafkaTopic
 
 trait SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event] extends SurgeGenericBusinessLogicTrait[AggId, Agg, Command, Rej, Event] {
 
   def eventsTopic: KafkaTopic
-  def writeFormatting: SurgeWriteFormatting[Agg, Event]
-  def readFormatting: SurgeAggregateReadFormatting[Agg]
 
-  override final def aggregateReadFormatting: SurgeAggregateReadFormatting[Agg] = readFormatting
-  final def eventWriteFormatting: SurgeEventWriteFormatting[Event] = writeFormatting
-  final override def aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg] = writeFormatting
+  def aggregateReadFormatting: SurgeAggregateReadFormatting[Agg]
+  def eventWriteFormatting: SurgeEventWriteFormatting[Event]
+  def aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg]
 
   def kafkaConfig: SurgeCommandKafkaConfig = new SurgeCommandKafkaConfig(
     stateTopic = stateTopic,

--- a/modules/command-engine/core/src/test/scala/surge/internal/persistence/PersistentActorSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/persistence/PersistentActorSpec.scala
@@ -127,8 +127,8 @@ class PersistentActorSpec
 
     probe.expectMsg(PersistentActor.ACKSuccess(expectedState))
 
-    val serializedEvent = businessLogic.writeFormatting.writeEvent(expectedEvent)
-    val serializedAgg = expectedState.map(businessLogic.writeFormatting.writeState)
+    val serializedEvent = businessLogic.eventWriteFormatting.writeEvent(expectedEvent)
+    val serializedAgg = expectedState.map(businessLogic.aggregateWriteFormatting.writeState)
     val expectedStateSerialized = KafkaProducerActor.MessageToPublish(state.aggregateId, serializedAgg.map(_.value).orNull, new RecordHeaders())
     val headers = HeadersHelper.createHeaders(serializedEvent.headers)
     val expectedEventSerialized = KafkaProducerActor.MessageToPublish(serializedEvent.key, serializedEvent.value, headers)

--- a/modules/common/src/main/scala/surge/core/SurgeFormatting.scala
+++ b/modules/common/src/main/scala/surge/core/SurgeFormatting.scala
@@ -13,7 +13,8 @@ trait SurgeAggregateReadFormatting[Agg] {
   def readState(bytes: Array[Byte]): Option[Agg]
 }
 
-//trait SurgeReadFormatting[Agg, Event] extends SurgeEventReadFormatting[Event] with SurgeAggregateReadFormatting[Agg]
+@deprecated("Encourages the use of an anti-pattern. Use SurgeEventReadFormatting and SurgeAggregateReadFormatting separately.", "0.5.4")
+trait SurgeReadFormatting[Agg, Event] extends SurgeEventReadFormatting[Event] with SurgeAggregateReadFormatting[Agg]
 
 trait SurgeEventWriteFormatting[Event] {
   def writeEvent(evt: Event): SerializedMessage
@@ -22,7 +23,9 @@ trait SurgeEventWriteFormatting[Event] {
 trait SurgeAggregateWriteFormatting[Agg] {
   def writeState(agg: Agg): SerializedAggregate
 }
-//trait SurgeWriteFormatting[Agg, Event] extends SurgeEventWriteFormatting[Event] with SurgeAggregateWriteFormatting[Agg]
+
+@deprecated("Encourages the use of an anti-pattern. Use SurgeAggregateWriteFormatting and SurgeEventWriteFormatting separately.", "0.5.4")
+trait SurgeWriteFormatting[Agg, Event] extends SurgeEventWriteFormatting[Event] with SurgeAggregateWriteFormatting[Agg]
 
 trait SurgeAggregateFormatting[Agg] extends SurgeAggregateReadFormatting[Agg] with SurgeAggregateWriteFormatting[Agg]
 trait SurgeEventFormatting[Event] extends SurgeEventReadFormatting[Event] with SurgeEventWriteFormatting[Event]

--- a/modules/common/src/main/scala/surge/core/SurgeFormatting.scala
+++ b/modules/common/src/main/scala/surge/core/SurgeFormatting.scala
@@ -13,7 +13,7 @@ trait SurgeAggregateReadFormatting[Agg] {
   def readState(bytes: Array[Byte]): Option[Agg]
 }
 
-trait SurgeReadFormatting[Agg, Event] extends SurgeEventReadFormatting[Event] with SurgeAggregateReadFormatting[Agg]
+//trait SurgeReadFormatting[Agg, Event] extends SurgeEventReadFormatting[Event] with SurgeAggregateReadFormatting[Agg]
 
 trait SurgeEventWriteFormatting[Event] {
   def writeEvent(evt: Event): SerializedMessage
@@ -22,7 +22,7 @@ trait SurgeEventWriteFormatting[Event] {
 trait SurgeAggregateWriteFormatting[Agg] {
   def writeState(agg: Agg): SerializedAggregate
 }
-trait SurgeWriteFormatting[Agg, Event] extends SurgeEventWriteFormatting[Event] with SurgeAggregateWriteFormatting[Agg]
+//trait SurgeWriteFormatting[Agg, Event] extends SurgeEventWriteFormatting[Event] with SurgeAggregateWriteFormatting[Agg]
 
 trait SurgeAggregateFormatting[Agg] extends SurgeAggregateReadFormatting[Agg] with SurgeAggregateWriteFormatting[Agg]
 trait SurgeEventFormatting[Event] extends SurgeEventReadFormatting[Event] with SurgeEventWriteFormatting[Event]

--- a/modules/surge-docs/src/test/scala/docs/command/BankAccountSurgeModel.scala
+++ b/modules/surge-docs/src/test/scala/docs/command/BankAccountSurgeModel.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.ConfigFactory
 
 import java.util.UUID
 import play.api.libs.json.Json
-import surge.core.{ SerializedAggregate, SerializedMessage, SurgeAggregateReadFormatting, SurgeWriteFormatting }
+import surge.core.{ SerializedAggregate, SerializedMessage, SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting }
 import surge.kafka.KafkaTopic
 import surge.scaladsl.command.{ AggregateCommandModel, SurgeCommandBusinessLogic }
 
@@ -20,21 +20,24 @@ object BankAccountSurgeModel extends SurgeCommandBusinessLogic[UUID, BankAccount
 
   override def eventsTopic: KafkaTopic = KafkaTopic("bank-account-events")
 
-  override def readFormatting: SurgeAggregateReadFormatting[BankAccount] = (bytes: Array[Byte]) => Json.parse(bytes).asOpt[BankAccount]
+  override def aggregateReadFormatting: SurgeAggregateReadFormatting[BankAccount] = (bytes: Array[Byte]) => Json.parse(bytes).asOpt[BankAccount]
 
-  override def writeFormatting: SurgeWriteFormatting[BankAccount, BankAccountEvent] = new SurgeWriteFormatting[BankAccount, BankAccountEvent] {
+  override def aggregateWriteFormatting: SurgeAggregateWriteFormatting[BankAccount] = new SurgeAggregateWriteFormatting[BankAccount] {
     override def writeState(agg: BankAccount): SerializedAggregate = {
       val aggBytes = Json.toJson(agg).toString().getBytes()
       val messageHeaders = Map("aggregate_id" -> agg.accountNumber.toString)
       SerializedAggregate(aggBytes, messageHeaders)
     }
+  }
 
+  override def eventWriteFormatting: SurgeEventWriteFormatting[BankAccountEvent] = new SurgeEventWriteFormatting[BankAccountEvent] {
     override def writeEvent(evt: BankAccountEvent): SerializedMessage = {
       val evtKey = evt.accountNumber.toString
       val evtBytes = evt.toJson.toString().getBytes()
       val messageHeaders = Map("aggregate_id" -> evt.accountNumber.toString)
       SerializedMessage(evtKey, evtBytes, messageHeaders)
     }
+
   }
 }
 // #surge_model_class


### PR DESCRIPTION
This is required for analogous changes in surge-ukg