### PR TITLE
Retry publisher creation less frequently on Kafka authorization errors

### DIFF
--- a/modules/command-engine/core/src/main/resources/reference.conf
+++ b/modules/command-engine/core/src/main/resources/reference.conf
@@ -36,15 +36,18 @@ kafka {
     ktable-check-interval = ${?KAFKA_PUBLISHER_INITIALIZATION_INTERVAL}
 
     init-transactions {
+      # The time the producer actor will wait before attempting to re-initialize transactions when the broker returns an authorization exception
       authz-exception-retry-time = 1 minute
       authz-exception-retry-time = ${?KAFKA_PUBLISHER_INIT_TRANSACTIONS_AUTHZ_RETRY_TIME}
 
+      # The time the producer actor will wait before attempting to re-initialize transactions on any exception not already handled by another retry time
       other-exception-retry-time = 3 seconds
       other-exception-retry-time = ${?KAFKA_PUBLISHER_INIT_TRANSACTIONS_RETRY_TIME}
     }
   }
 }
 
+# Thread pool used for serializing events & state before they're sent to Kafka
 surge {
   serialization {
     thread-pool-size = 32

--- a/modules/command-engine/core/src/main/resources/reference.conf
+++ b/modules/command-engine/core/src/main/resources/reference.conf
@@ -34,6 +34,14 @@ kafka {
 
     ktable-check-interval = 500 milliseconds
     ktable-check-interval = ${?KAFKA_PUBLISHER_INITIALIZATION_INTERVAL}
+
+    init-transactions {
+      authz-exception-retry-time = 1 minute
+      authz-exception-retry-time = ${?KAFKA_PUBLISHER_INIT_TRANSACTIONS_AUTHZ_RETRY_TIME}
+
+      other-exception-retry-time = 3 seconds
+      other-exception-retry-time = ${?KAFKA_PUBLISHER_INIT_TRANSACTIONS_RETRY_TIME}
+    }
   }
 }
 

--- a/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
@@ -4,11 +4,11 @@ package surge.internal.kafka
 
 import akka.actor.{ ActorRef, NoSerializationVerificationNeeded, Stash, Status, Timers }
 import akka.pattern._
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 import io.opentracing.Tracer
 import org.apache.kafka.clients.producer.{ ProducerConfig, ProducerRecord }
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.ProducerFencedException
+import org.apache.kafka.common.errors.{ AuthorizationException, ProducerFencedException }
 import org.apache.kafka.streams.LagInfo
 import org.slf4j.{ Logger, LoggerFactory }
 import surge.core.KafkaProducerActor
@@ -70,6 +70,7 @@ class KafkaProducerActorImpl(
     producerContext: ProducerActorContext,
     kStreams: AggregateStateStoreKafkaStreams[_],
     partitionTracker: KafkaConsumerPartitionAssignmentTracker,
+    config: Config = ConfigFactory.load(),
     kafkaProducerOverride: Option[KafkaBytesProducer] = None)
     extends ActorWithTracing
     with ActorHostAwareness
@@ -83,7 +84,6 @@ class KafkaProducerActorImpl(
 
   private val log: Logger = LoggerFactory.getLogger(getClass)
 
-  private val config = ConfigFactory.load()
   private val assignedTopicPartitionKey = s"${assignedPartition.topic}:${assignedPartition.partition}"
   private val flushInterval = config.getDuration("kafka.publisher.flush-interval", TimeUnit.MILLISECONDS).milliseconds
   private val publisherBatchSize = config.getInt("kafka.publisher.batch-size")
@@ -93,6 +93,10 @@ class KafkaProducerActorImpl(
   private val ktableCheckInterval = config.getDuration("kafka.publisher.ktable-check-interval").toMillis.milliseconds
   private val brokers = config.getString("kafka.brokers").split(",").toVector
   private val enableMetrics = config.getBoolean("surge.producer.enable-kafka-metrics")
+  private val initTransactionAuthzExceptionRetryDuration =
+    config.getDuration("kafka.publisher.init-transactions.authz-exception-retry-time").toMillis.millis.toCoarsest
+  private val initTransactionOtherExceptionRetryDuration =
+    config.getDuration("kafka.publisher.init-transactions.other-exception-retry-time").toMillis.millis.toCoarsest
 
   private val transactionalId = s"$transactionalIdPrefix-${assignedPartition.topic()}-${assignedPartition.partition()}"
   private val kafkaPublisherMetricsName = transactionalId
@@ -206,10 +210,21 @@ class KafkaProducerActorImpl(
         self ! InitTransactionSuccess
       }
       .recover { case err: Throwable =>
-        log.error(s"KafkaPublisherActor failed to initialize kafka transactions, retrying in 3 seconds: $assignedPartition", err)
+        val retryTime = initTransactionsRetryTimeFromError(err)
+        log.error(
+          s"KafkaPublisherActor failed to initialize kafka transactions with transactional id [$transactionalId] " +
+            s"for partition [$assignedPartition], retrying in $retryTime",
+          err)
         closeAndRecreatePublisher()
-        context.system.scheduler.scheduleOnce(3.seconds, self, InitTransactions)
+        context.system.scheduler.scheduleOnce(retryTime, self, InitTransactions)
       }
+  }
+
+  private def initTransactionsRetryTimeFromError(err: Throwable): FiniteDuration = {
+    err match {
+      case _: AuthorizationException => initTransactionAuthzExceptionRetryDuration
+      case _                         => initTransactionOtherExceptionRetryDuration
+    }
   }
 
   private def closeAndRecreatePublisher(): Unit = {

--- a/modules/common/src/main/resources/reference.conf
+++ b/modules/common/src/main/resources/reference.conf
@@ -39,6 +39,18 @@ kafka {
       compaction-parallelism = 2
       compaction-parallelism = ${?KAFKA_STREAMS_ROCKSDB_COMPACTION_PARALLELISM}
 
+      # The number of memtables that rocksdb will use when writing data to a KTable backed by rocksdb
+      num-write-buffers = 2
+      num-write-buffers = ${?KAFKA_STREAMS_ROCKSDB_NUM_WRITE_BUFFERS}
+
+      # The size of each memtable that rocksdb will use when writing data to a KTable backed by rocksdb
+      write-buffer-size-mb = 16
+      write-buffer-size-mb = ${?KAFKA_STREAMS_ROCKSDB_WRITE_BUFFER_SIZE_MB}
+
+      # The size of the block cache that rocksdb will use when writing data to a KTable backed by rocksdb
+      block-cache-size-mb = 16
+      block-cache-size-mb = ${?KAFKA_STREAMS_ROCKSDB_BLOCK_CACHE_SIZE_MB}
+
       # Used for debug and performance tuning, setting this to true will cause rocksdb to print
       # performance statistics to a log file in the same directory as rocksdb uses to spill sstfiles to disk
       dump-statistics = false

--- a/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
@@ -5,24 +5,28 @@ package surge.kafka.streams
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.pattern.{ ask, BackoffOpts, BackoffSupervisor }
 import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
 import org.apache.kafka.streams.{ LagInfo, Topology }
 import surge.internal.config.{ BackoffConfig, TimeoutConfig }
 import surge.internal.utils.{ BackoffChildActorTerminationWatcher, Logging }
 import surge.kafka.KafkaTopic
 import surge.kafka.streams.AggregateStateStoreKafkaStreamsImpl._
+import surge.kafka.streams.AggregateStreamsWriteBufferSettings.config
 import surge.kafka.streams.KafkaStreamLifeCycleManagement.{ Restart, Start, Stop }
 import surge.metrics.Metrics
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 object AggregateStreamsWriteBufferSettings extends WriteBufferSettings {
-  override def maxWriteBufferNumber: Int = 2
-  override def writeBufferSizeMb: Int = 32
+  private val config = ConfigFactory.load()
+  override def maxWriteBufferNumber: Int = config.getInt("kafka.streams.rocks-db.num-write-buffers")
+  override def writeBufferSizeMb: Int = config.getInt("kafka.streams.rocks-db.write-buffer-size-mb")
 }
 
 object AggregateStreamsBlockCacheSettings extends BlockCacheSettings {
+  private val config = ConfigFactory.load()
   override def blockSizeKb: Int = 16
-  override def blockCacheSizeMb: Int = 16
+  override def blockCacheSizeMb: Int = config.getInt("kafka.streams.rocks-db.block-cache-size-mb")
   override def cacheIndexAndFilterBlocks: Boolean = true
 }
 


### PR DESCRIPTION
Kafka Authorization errors aren't really intermittent and usually require some manual intervention outside of the app to fix - either by changing the resource your app is trying to access to something it has permissions for or correcting the ACLs on the broker side.  This change reduces the default retry time on authorization errors in the KafkaProducerActor from 3 seconds to 1 minute and exposes configuration settings to allow overriding the retry time if desired.

Additionally exposes configuration options for RocksDB write buffers and block cache so that applications can more easily tune memory used by Surge.