### PR TITLE
Fix Create Release Notes GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
         id: draft_release


### PR DESCRIPTION
This repo doesn't have any self-hosted runners, but we can just run on ubuntu-latest.