### PR TITLE
Remove some dead code

### DIFF
--- a/modules/common/src/main/scala/surge/internal/config/BackoffConfig.scala
+++ b/modules/common/src/main/scala/surge/internal/config/BackoffConfig.scala
@@ -14,13 +14,6 @@ object BackoffConfig {
     val maxRetries = config.getInt("surge.state-store-actor.backoff.max-retries")
   }
 
-  object GlobalKTableKafkaStreamActor {
-    val minBackoff = config.getDuration("surge.global-ktable-actor.backoff.min-backoff")
-    val maxBackoff = config.getDuration("surge.global-ktable-actor.backoff.max-backoff")
-    val randomFactor = config.getDouble("surge.global-ktable-actor.backoff.random-factor")
-    val maxRetries = config.getInt("surge.global-ktable-actor.backoff.max-retries")
-  }
-
   object HealthSignalWindowActor {
     val minBackoff = config.getDuration("surge.health.window-actor.backoff.min-backoff")
     val maxBackoff = config.getDuration("surge.health.window-actor.backoff.max-backoff")


### PR DESCRIPTION
My understanding is that Surge doesn't use a Global KTable and this code is never used. So let's remove it. WDYT ?