### PR TITLE
Replace KTable lag check with Kafka AdminClient

### DIFF
--- a/modules/command-engine/core/src/test/scala/org/apache/kafka/streams/MockLagInfo.scala
+++ b/modules/command-engine/core/src/test/scala/org/apache/kafka/streams/MockLagInfo.scala
@@ -1,7 +1,0 @@
-// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
-
-package org.apache.kafka.streams
-
-// Create this here since we create instances of this simple object for various tests, but the constructor
-// for LagInfo is not public
-class MockLagInfo(currentOffset: Long, endOffset: Long) extends LagInfo(currentOffset, endOffset)

--- a/modules/common/src/main/scala/surge/kafka/KafkaAdminClient.scala
+++ b/modules/common/src/main/scala/surge/kafka/KafkaAdminClient.scala
@@ -1,0 +1,55 @@
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
+package surge.kafka
+
+import java.util.Properties
+
+import org.apache.kafka.clients.admin.{ Admin, ListOffsetsOptions, OffsetSpec }
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo
+import org.apache.kafka.clients.consumer.{ ConsumerConfig, OffsetAndMetadata }
+import org.apache.kafka.common.TopicPartition
+
+import scala.jdk.CollectionConverters._
+
+case class LagInfo(currentOffsetPosition: Long, endOffsetPosition: Long) {
+  val offsetLag: Long = Math.max(0, endOffsetPosition - currentOffsetPosition)
+}
+
+object KafkaAdminClient extends KafkaSecurityConfiguration {
+  def apply(brokers: Seq[String]): KafkaAdminClient = {
+    val p = new Properties()
+    p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers.mkString(","))
+    configureSecurityProperties(p)
+    apply(p)
+  }
+
+  def apply(props: Properties): KafkaAdminClient = {
+    new KafkaAdminClient(props)
+  }
+}
+
+class KafkaAdminClient(props: Properties) extends KafkaSecurityConfiguration {
+  private val client = Admin.create(props)
+
+  def consumerGroupOffsets(groupName: String): Map[TopicPartition, OffsetAndMetadata] = {
+    client.listConsumerGroupOffsets(groupName).partitionsToOffsetAndMetadata().get().asScala.toMap
+  }
+
+  def endOffsets(partitions: List[TopicPartition], options: ListOffsetsOptions = new ListOffsetsOptions()): Map[TopicPartition, ListOffsetsResultInfo] = {
+    client.listOffsets(partitions.map(tp => tp -> OffsetSpec.latest()).toMap.asJava).all().get().asScala.toMap
+  }
+
+  def consumerLag(
+      groupName: String,
+      topicPartitions: List[TopicPartition],
+      listOffsetsOptions: ListOffsetsOptions = new ListOffsetsOptions()): Map[TopicPartition, LagInfo] = {
+    val cgOffsets = consumerGroupOffsets(groupName)
+    val tpEndOffsets = endOffsets(topicPartitions, listOffsetsOptions)
+
+    tpEndOffsets.map { case (topicPartition, endOffsetMeta) =>
+      val cgOffset = cgOffsets.getOrElse(topicPartition, new OffsetAndMetadata(0L))
+      val lagInfo = LagInfo(cgOffset.offset(), endOffsetMeta.offset())
+      topicPartition -> lagInfo
+    }
+  }
+}

--- a/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
@@ -8,11 +8,12 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.pattern.{ ask, BackoffOpts, BackoffSupervisor }
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
-import org.apache.kafka.streams.{ LagInfo, Topology }
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.streams.Topology
 import surge.health.HealthSignalBusTrait
 import surge.internal.config.{ BackoffConfig, TimeoutConfig }
 import surge.internal.utils.{ BackoffChildActorTerminationWatcher, Logging }
-import surge.kafka.KafkaTopic
+import surge.kafka.{ KafkaTopic, LagInfo }
 import surge.kafka.streams.AggregateStateStoreKafkaStreamsImpl._
 import surge.kafka.streams.KafkaStreamLifeCycleManagement.{ Restart, Start, Stop }
 import surge.metrics.Metrics
@@ -112,8 +113,8 @@ class AggregateStateStoreKafkaStreams[Agg >: Null](
     underlyingActor ! Restart
   }
 
-  def partitionLags()(implicit ec: ExecutionContext): Future[Map[String, Map[java.lang.Integer, LagInfo]]] = {
-    underlyingActor.ask(GetLocalStorePartitionLags).mapTo[LocalStorePartitionLags].map(_.lags)
+  def partitionLag(topicPartition: TopicPartition)(implicit ec: ExecutionContext): Future[Option[LagInfo]] = {
+    underlyingActor.ask(GetPartitionLag(topicPartition)).mapTo[PartitionLagResponse].map(_.lag)
   }
 
   def getAggregateBytes(aggregateId: String): Future[Option[Array[Byte]]] = {

--- a/modules/common/src/test/scala/surge/kafka/KafkaAdminClientSpec.scala
+++ b/modules/common/src/test/scala/surge/kafka/KafkaAdminClientSpec.scala
@@ -1,0 +1,58 @@
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
+package surge.kafka
+
+import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.{ Serializer, StringSerializer }
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Millis, Seconds, Span }
+import org.scalatest.wordspec.AnyWordSpec
+
+class KafkaAdminClientSpec extends AnyWordSpec with Matchers with EmbeddedKafka with Eventually {
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(10, Millis)))
+
+  "KafkaAdminClient" should {
+    "Correctly calculate consumer lag" in {
+      withRunningKafkaOnFoundPort(EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)) { implicit actualConfig =>
+        implicit val stringSerializer: Serializer[String] = new StringSerializer
+        val topic = KafkaTopic("test-topic")
+        createCustomTopic(topic.name, partitions = 3)
+        val partition0 = new TopicPartition(topic.name, 0)
+        val partition1 = new TopicPartition(topic.name, 1)
+        val partition2 = new TopicPartition(topic.name, 2)
+        val embeddedBroker = s"localhost:${actualConfig.kafkaPort}"
+        val client = KafkaAdminClient(Seq(embeddedBroker))
+
+        val consumerGroupName = "test-consumer-group"
+        val consumer = KafkaStringConsumer(Seq(embeddedBroker), UltiKafkaConsumerConfig(consumerGroupName), Map.empty).consumer
+        consumer.subscribe(java.util.Arrays.asList(topic.name))
+
+        publishToKafka(new ProducerRecord[String, String](topic.name, 0, "", "initial value"))
+        client.consumerLag(consumerGroupName, List(partition0)) shouldEqual Map(partition0 -> LagInfo(0L, 1L))
+
+        client.consumerLag("non-existent-consumer-group", List(partition0)) shouldEqual Map(partition0 -> LagInfo(0L, 1L))
+
+        publishToKafka(new ProducerRecord[String, String](topic.name, 1, "", "partition 1 value"))
+        publishToKafka(new ProducerRecord[String, String](topic.name, 1, "", "partition 1 second value"))
+        client.consumerLag(consumerGroupName, List(partition0, partition1, partition2)) shouldEqual Map(
+          partition0 -> LagInfo(0L, 1L),
+          partition1 -> LagInfo(0L, 2L),
+          partition2 -> LagInfo(0L, 0L))
+
+        eventually {
+          consumer.poll(java.time.Duration.ofMillis(50))
+          consumer.commitSync()
+
+          client.consumerLag(consumerGroupName, List(partition0, partition1, partition2)) shouldEqual Map(
+            partition0 -> LagInfo(1L, 1L),
+            partition1 -> LagInfo(2L, 2L),
+            partition2 -> LagInfo(0L, 0L))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `allLocalStorePartitionLags()` function we use to check the lag of the KStreams consumer as it indexes the state topic to the KTable only works when enabling change logging in the stream. Change logging doesn't necessarily need to be a requirement of Surge, and in fact doesn't really work well with custom state store implementations.  The logic for checking offsets isn't too complicated so we can just use a simple Kafka AdminClient to check lag on the topic for our KStreams consumer instead of the built in KStreams function that does require them.