### PR TITLE
Properly wrap and handle exceptions thrown by processCommand in the javadsl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,10 @@ lazy val `surge-engine-command-core` = (project in file("modules/command-engine/
 
 lazy val `surge-engine-command-scaladsl` = (project in file("modules/command-engine/scaladsl")).dependsOn(`surge-engine-command-core`)
 
-lazy val `surge-engine-command-javadsl` = (project in file("modules/command-engine/javadsl")).dependsOn(`surge-engine-command-core`)
+lazy val `surge-engine-command-javadsl` =
+  (project in file("modules/command-engine/javadsl"))
+    .dependsOn(`surge-engine-command-core`)
+    .settings(libraryDependencies ++= Seq(scalatest, scalatestPlusMockito, mockitoCore))
 
 lazy val `surge-metrics` = (project in file("modules/metrics")).settings(
   libraryDependencies ++= Seq(

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/CommandModels.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/CommandModels.scala
@@ -3,18 +3,18 @@
 package surge.javadsl.command
 
 import surge.core.command.AggregateCommandModelCoreTrait
-import surge.internal
 import surge.internal.domain.CommandHandler
 import surge.internal.persistence
 import surge.javadsl._
 import surge.javadsl.common.Context
-
 import java.util.concurrent.CompletableFuture
 import java.util.{ Optional, List => JList }
+
 import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 trait AggregateCommandModel[Agg, Cmd, Evt] extends AggregateCommandModelCoreTrait[Agg, Cmd, Nothing, Evt] {
   def processCommand(aggregate: Optional[Agg], command: Cmd): JList[Evt]
@@ -23,7 +23,7 @@ trait AggregateCommandModel[Agg, Cmd, Evt] extends AggregateCommandModelCoreTrai
   final def toCore: CommandHandler[Agg, Cmd, Nothing, Evt] =
     new CommandHandler[Agg, Cmd, Nothing, Evt] {
       override def processCommand(ctx: persistence.Context, state: Option[Agg], cmd: Cmd): Future[CommandResult] =
-        Future.successful(Right(AggregateCommandModel.this.processCommand(state.asJava, cmd).asScala.toSeq))
+        Future.fromTry(Try(Right(AggregateCommandModel.this.processCommand(state.asJava, cmd).asScala.toSeq)))
       override def apply(ctx: persistence.Context, state: Option[Agg], event: Evt): Option[Agg] = handleEvent(state.asJava, event).asScala
     }
 }

--- a/modules/command-engine/javadsl/src/test/scala/surge/javadsl/command/CommandModelsSpec.scala
+++ b/modules/command-engine/javadsl/src/test/scala/surge/javadsl/command/CommandModelsSpec.scala
@@ -1,0 +1,28 @@
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
+package surge.javadsl.command
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import surge.internal.persistence.Context
+
+import java.util
+import java.util.Optional
+import scala.util.control.NoStackTrace
+
+class CommandModelsSpec extends AsyncWordSpec with Matchers with MockitoSugar with ScalaFutures {
+  "AggregateCommandModel" should {
+    "Return a failed future when the business logic throws an exception processing commands" in {
+      val expectedException = new RuntimeException("This is expected") with NoStackTrace
+      val exceptionThrowingModel = new AggregateCommandModel[String, String, String] {
+        override def processCommand(aggregate: Optional[String], command: String): util.List[String] = throw expectedException
+        override def handleEvent(aggregate: Optional[String], event: String): Optional[String] = Optional.empty()
+      }
+      recoverToSucceededIf[RuntimeException] {
+        exceptionThrowingModel.toCore.processCommand(mock[Context], None, "Test")
+      }
+    }
+  }
+}


### PR DESCRIPTION
In the javasdl for `AggregateCommandModel` specifically exceptions thrown by `processCommand` were not being correctly wrapped in a failed future.