### PR TITLE
Simplify KafkaProducerActor by removing pending initializations

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -8,12 +8,10 @@ import akka.util.Timeout
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.Headers
 import org.slf4j.LoggerFactory
-import java.time.Instant
-
-import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.health.{ HealthSignalBusAware, HealthSignalBusTrait }
 import surge.internal.SurgeModel
 import surge.internal.akka.actor.ActorLifecycleManagerActor
+import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.internal.config.TimeoutConfig
 import surge.internal.kafka.KafkaProducerActorImpl
 import surge.kafka.KafkaBytesProducer
@@ -79,9 +77,8 @@ class KafkaProducerActor(
       tags = Map("aggregate" -> aggregateName)))
   def isAggregateStateCurrent(aggregateId: String): Future[Boolean] = {
     implicit val askTimeout: Timeout = Timeout(TimeoutConfig.PublisherActor.aggregateStateCurrentTimeout)
-    val expirationTime = Instant.now.plusMillis(askTimeout.duration.toMillis)
     isAggregateStateCurrentTimer.time {
-      (publisherActor ? KafkaProducerActorImpl.IsAggregateStateCurrent(aggregateId, expirationTime)).mapTo[Boolean]
+      (publisherActor ? KafkaProducerActorImpl.IsAggregateStateCurrent(aggregateId)).mapTo[Boolean]
     }
   }
 

--- a/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
@@ -35,7 +35,7 @@ object KafkaProducerActorImpl {
 
   sealed trait KafkaProducerActorMessage extends NoSerializationVerificationNeeded
   case class Publish(state: KafkaProducerActor.MessageToPublish, eventsToPublish: Seq[KafkaProducerActor.MessageToPublish]) extends KafkaProducerActorMessage
-  case class IsAggregateStateCurrent(aggregateId: String, expirationTime: Instant) extends KafkaProducerActorMessage
+  case class IsAggregateStateCurrent(aggregateId: String) extends KafkaProducerActorMessage
 
   object AggregateStateRates {
     def apply(aggregateName: String, metrics: Metrics): AggregateStateRates = AggregateStateRates(
@@ -165,7 +165,7 @@ class KafkaProducerActorImpl(
     case GetHealth                  => doHealthCheck()
     case _: KTableProgressUpdate    => stash() // process only AFTER flush message is sent
     case _: Publish                 => stash()
-    case _: IsAggregateStateCurrent => stash()
+    case _: IsAggregateStateCurrent => sender().tell(false, self)
   }
 
   private def waitingForKTableIndexing(): Receive = {
@@ -173,7 +173,7 @@ class KafkaProducerActorImpl(
     case FlushMessages              => // Ignore from this state
     case GetHealth                  => doHealthCheck()
     case _: Publish                 => stash()
-    case _: IsAggregateStateCurrent => stash()
+    case _: IsAggregateStateCurrent => sender().tell(false, self)
   }
 
   private def fenced(state: KafkaProducerActorState): Receive = {
@@ -272,7 +272,7 @@ class KafkaProducerActorImpl(
       unstashAll()
       context.become(processing(KafkaProducerActorState.empty))
     } else {
-      log.debug("Producer actor still waiting for KTable to finish indexing, current lag is {}", kTableProgressUpdate.lagInfo)
+      log.debug("Producer actor still waiting for KTable to finish indexing, current lag is {}", kTableProgressUpdate.lagInfo.offsetLag)
     }
   }
 
@@ -414,12 +414,12 @@ class KafkaProducerActorImpl(
   private def handle(state: KafkaProducerActorState, isAggregateStateCurrent: IsAggregateStateCurrent): Unit = {
     val aggregateId = isAggregateStateCurrent.aggregateId
     val noRecordsInFlight = state.inFlightForAggregate(aggregateId).isEmpty
+    sender() ! noRecordsInFlight
 
     if (noRecordsInFlight) {
       rates.current.mark()
-      sender() ! noRecordsInFlight
     } else {
-      context.become(processing(state.addPendingInitialization(sender(), isAggregateStateCurrent)))
+      rates.notCurrent.mark()
     }
   }
 
@@ -444,7 +444,6 @@ class KafkaProducerActorImpl(
       details = Some(
         Map(
           "inFlight" -> state.inFlight.size.toString,
-          "pendingInitializations" -> state.pendingInitializations.size.toString,
           "pendingWrites" -> state.pendingWrites.size.toString,
           "currentTransactionTimeMillis" -> state.currentTransactionTimeMillis.toString)))
     sender() ! healthCheck
@@ -453,7 +452,7 @@ class KafkaProducerActorImpl(
 
 private[internal] object KafkaProducerActorState {
   def empty(implicit sender: ActorRef, rates: KafkaProducerActorImpl.AggregateStateRates): KafkaProducerActorState = {
-    KafkaProducerActorState(Seq.empty, Seq.empty, Seq.empty, transactionInProgressSince = None, sender = sender, rates = rates)
+    KafkaProducerActorState(Seq.empty, Seq.empty, transactionInProgressSince = None, sender = sender, rates = rates)
   }
 }
 // TODO optimize:
@@ -461,7 +460,6 @@ private[internal] object KafkaProducerActorState {
 private[internal] case class KafkaProducerActorState(
     inFlight: Seq[KafkaRecordMetadata[String]],
     pendingWrites: Seq[KafkaProducerActorImpl.PublishWithSender],
-    pendingInitializations: Seq[KafkaProducerActorImpl.PendingInitialization],
     transactionInProgressSince: Option[Instant],
     sender: ActorRef,
     rates: KafkaProducerActorImpl.AggregateStateRates) {
@@ -482,12 +480,6 @@ private[internal] case class KafkaProducerActorState(
 
   def inFlightForAggregate(aggregateId: String): Seq[KafkaRecordMetadata[String]] = {
     inFlightByKey.getOrElse(aggregateId, Seq.empty)
-  }
-
-  def addPendingInitialization(sender: ActorRef, isAggregateStateCurrent: IsAggregateStateCurrent): KafkaProducerActorState = {
-    val pendingInitialization = PendingInitialization(sender, isAggregateStateCurrent.aggregateId, isAggregateStateCurrent.expirationTime)
-
-    this.copy(pendingInitializations = pendingInitializations :+ pendingInitialization)
   }
 
   def addPendingWrites(sender: ActorRef, publish: Publish): KafkaProducerActorState = {
@@ -527,29 +519,6 @@ private[internal] case class KafkaProducerActorState(
     }
     val newInFlight = inFlight.filterNot(processedRecordsFromPartition.contains)
 
-    val newPendingAggregates = {
-      val processedAggregates = pendingInitializations.filter { pending =>
-        !newInFlight.exists(_.key.contains(pending.key))
-      }
-      if (processedAggregates.nonEmpty) {
-        processedAggregates.foreach { pending =>
-          pending.actor ! true // scalastyle:ignore simplify.boolean.expression
-        }
-        rates.current.mark(processedAggregates.length)
-      }
-
-      val expiredAggregates = pendingInitializations.filter(pending => Instant.now().isAfter(pending.expiration)).filterNot(processedAggregates.contains)
-
-      if (expiredAggregates.nonEmpty) {
-        expiredAggregates.foreach { pending =>
-          log.debug(s"Aggregate ${pending.key} expiring since it is past ${pending.expiration}")
-          pending.actor ! false // scalastyle:ignore simplify.boolean.expression
-        }
-        rates.notCurrent.mark(expiredAggregates.length)
-      }
-      pendingInitializations.filterNot(agg => processedAggregates.contains(agg) || expiredAggregates.contains(agg))
-    }
-
-    copy(inFlight = newInFlight, pendingInitializations = newPendingAggregates)
+    copy(inFlight = newInFlight)
   }
 }

--- a/modules/command-engine/core/src/test/scala/surge/internal/kafka/KafkaProducerActorImplSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/kafka/KafkaProducerActorImplSpec.scala
@@ -27,14 +27,15 @@ import surge.internal.kafka.KafkaProducerActorImpl.{ AggregateStateRates, KTable
 import surge.kafka.streams.AggregateStateStoreKafkaStreams
 import surge.kafka.{ KafkaBytesProducer, KafkaRecordMetadata, LagInfo, PartitionAssignments }
 import surge.metrics.Metrics
-import java.time.Instant
 
+import java.time.Instant
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import surge.internal.akka.cluster.ActorSystemHostAwareness
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.util.control.NoStackTrace
 
 class KafkaProducerActorImplSpec
     extends TestKit(ActorSystem("KafkaProducerActorImplSpec"))
@@ -49,6 +50,7 @@ class KafkaProducerActorImplSpec
 
   override val actorSystem: ActorSystem = system
 
+  private implicit val actorAskTimeout: Timeout = Timeout(10.seconds)
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(3, Seconds), interval = Span(10, Millis))
 
   override def afterAll(): Unit = {
@@ -141,6 +143,9 @@ class KafkaProducerActorImplSpec
     doNothing().when(mockProducer).commitTransaction()
   }
 
+  private val illegalStateException = new IllegalStateException("This is expected") with NoStackTrace
+  private val runtimeException = new RuntimeException("This is expected") with NoStackTrace
+
   "KafkaProducerActorImpl" should {
     val testEvents1 = testObjects(Seq("event1", "event2", "event3"))
     val testAggs1 = KafkaProducerActor.MessageToPublish("agg1", "agg1".getBytes(), new RecordHeaders())
@@ -154,7 +159,7 @@ class KafkaProducerActorImplSpec
       val mockMetadata = mockRecordMetadata(assignedPartition)
       when(mockProducer.initTransactions()(any[ExecutionContext])).thenReturn(Future.unit)
       // Fail first transaction and then succeed always
-      doThrow(new IllegalStateException("This is expected")).doNothing().when(mockProducer).beginTransaction()
+      doThrow(illegalStateException).doNothing().when(mockProducer).beginTransaction()
       doNothing().when(mockProducer).abortTransaction()
       doNothing().when(mockProducer).commitTransaction()
 
@@ -188,8 +193,8 @@ class KafkaProducerActorImplSpec
       // Fail first transaction and then succeed always
       doNothing().when(mockProducer).beginTransaction()
       doNothing().when(mockProducer).close()
-      doThrow(new IllegalStateException("This is expected")).when(mockProducer).abortTransaction()
-      doThrow(new IllegalStateException("This is expected")).doNothing().when(mockProducer).commitTransaction()
+      doThrow(illegalStateException).when(mockProducer).abortTransaction()
+      doThrow(illegalStateException).doNothing().when(mockProducer).commitTransaction()
 
       when(mockProducer.putRecords(any[Seq[ProducerRecord[String, Array[Byte]]]])).thenReturn(Seq(Future.successful(mockMetadata)))
 
@@ -219,7 +224,7 @@ class KafkaProducerActorImplSpec
 
       when(mockProducer.initTransactions()(any[ExecutionContext]))
         .thenReturn(Future.failed(new AuthorizationException("This is expected")))
-        .thenReturn(Future.failed(new IllegalStateException("This is expected")))
+        .thenReturn(Future.failed(illegalStateException))
         .thenReturn(Future.unit)
       when(mockProducer.putRecords(any[Seq[ProducerRecord[String, Array[Byte]]]])).thenReturn(Seq(Future.successful(mockMetadata)))
 
@@ -240,7 +245,7 @@ class KafkaProducerActorImplSpec
         10.seconds)
     }
 
-    "Stash IsAggregateStateCurrent messages until fully initialized when no messages inflight" in {
+    "Reply with false to IsAggregateStateCurrent messages when uninitialized" in {
       val probe = TestProbe()
       val assignedPartition = new TopicPartition("testTopic", 1)
       val mockProducer = mock[KafkaBytesProducer]
@@ -249,22 +254,19 @@ class KafkaProducerActorImplSpec
       when(mockProducer.putRecords(any[Seq[ProducerRecord[String, Array[Byte]]]])).thenReturn(Seq(Future.successful(mockMetadata)))
 
       val mockStateStore = mock[AggregateStateStoreKafkaStreams[String]]
-      when(mockStateStore.partitionLag(ArgumentMatchers.eq(assignedPartition))(any[ExecutionContext]))
-        .thenReturn(Future.successful(Some(LagInfo(0, 10))), Future.successful(Some(LagInfo(10, 10))))
+      when(mockStateStore.partitionLag(ArgumentMatchers.eq(assignedPartition))(any[ExecutionContext])).thenReturn(Future.successful(Some(LagInfo(0, 10))))
 
       val actor = testProducerActor(assignedPartition, mockProducer, mockStateStore)
       probe.send(actor, KafkaProducerActorImpl.Publish(testAggs1, testEvents1))
       // Send IsAggregateStateCurrent messages to stash
-      val isAggregateStateCurrent = KafkaProducerActorImpl.IsAggregateStateCurrent("bar", Instant.now.plusSeconds(10L))
+      val isAggregateStateCurrent = KafkaProducerActorImpl.IsAggregateStateCurrent("bar")
       probe.send(actor, isAggregateStateCurrent)
       // Verify that we haven't initialized transactions yet so we are in the uninitialized state and messages were stashed
       verify(mockProducer, times(0)).initTransactions()(any[ExecutionContext])
-      val response =
-        actor.ask(isAggregateStateCurrent)(10.seconds).map(Some(_))(system.dispatcher).recoverWith { case _ => Future.successful(None) }(system.dispatcher)
-      assert(Await.result(response, 10.seconds).isDefined)
+      probe.expectMsg(false)
     }
 
-    "Answer to IsAggregateStateCurrent when messages in flight" in {
+    "Determine if an aggregate state is up to date in the KTable based on recently published messages" in {
       val probe = TestProbe()
       val assignedPartition = new TopicPartition("testTopic", 1)
       val mockProducer = mock[KafkaBytesProducer]
@@ -282,12 +284,13 @@ class KafkaProducerActorImplSpec
         10.seconds,
         1.second)
 
-      val barRecord1 = KafkaRecordMetadata(Some("bar"), createRecordMeta("testTopic", 0, 0))
+      val barRecord1 = KafkaRecordMetadata(Some("bar"), createRecordMeta("testTopic", 0, 101))
       probe.send(actor, KafkaProducerActorImpl.EventsPublished(Seq(probe.ref), Seq(barRecord1)))
-      val isAggregateStateCurrent = KafkaProducerActorImpl.IsAggregateStateCurrent("bar", Instant.now.plusSeconds(10L))
-      val response =
-        actor.ask(isAggregateStateCurrent)(10.seconds).map(Some(_))(system.dispatcher).recoverWith { case _ => Future.successful(None) }(system.dispatcher)
-      assert(Await.result(response, 3.second).isDefined)
+      val isAggregateStateCurrent = KafkaProducerActorImpl.IsAggregateStateCurrent("bar")
+      actor.ask(isAggregateStateCurrent).futureValue shouldEqual false
+      // Simulate the KTable processing the recently published message
+      probe.send(actor, KTableProgressUpdate(assignedPartition, LagInfo(101, 101)))
+      actor.ask(isAggregateStateCurrent).futureValue shouldEqual true
     }
 
     "Stash Publish messages and publish them when fully initialized" in {
@@ -322,7 +325,7 @@ class KafkaProducerActorImplSpec
       val mockMetadata = mockRecordMetadata(assignedPartition)
       setupTransactions(mockProducerFailsPutRecords)
       when(mockProducerFailsPutRecords.putRecords(any[Seq[ProducerRecord[String, Array[Byte]]]]))
-        .thenReturn(Seq(Future.failed(new RuntimeException("This is expected"))), Seq(Future.successful(mockMetadata)))
+        .thenReturn(Seq(Future.failed(runtimeException)), Seq(Future.successful(mockMetadata)))
 
       probe.send(failingPut, KafkaProducerActorImpl.Publish(testAggs1, testEvents1))
       probe.send(failingPut, KafkaProducerActorImpl.FlushMessages)
@@ -348,7 +351,7 @@ class KafkaProducerActorImplSpec
       when(mockProducerFailsCommit.initTransactions()(any[ExecutionContext])).thenReturn(Future.unit)
       doNothing().when(mockProducerFailsCommit).beginTransaction()
       doNothing().when(mockProducerFailsCommit).abortTransaction()
-      when(mockProducerFailsCommit.commitTransaction()).thenThrow(new RuntimeException("This is expected"))
+      when(mockProducerFailsCommit.commitTransaction()).thenThrow(runtimeException)
 
       val mockMetadata = mockRecordMetadata(assignedPartition)
       when(mockProducerFailsCommit.putRecords(any[Seq[ProducerRecord[String, Array[Byte]]]])).thenReturn(Seq(Future.successful(mockMetadata)))
@@ -484,40 +487,6 @@ class KafkaProducerActorImplSpec
 
       val flushedState = newState.flushWrites()
       (flushedState.pendingWrites should have).length(0)
-    }
-
-    "Track pending aggregate initializations" in {
-      val empty = KafkaProducerActorState.empty
-
-      val upToDateProbe = TestProbe()
-      val isStateCurrentMsg = KafkaProducerActorImpl.IsAggregateStateCurrent("bar", Instant.now.plusSeconds(10L))
-      val expiredProbe = TestProbe()
-      val isStateCurrentMsg2 = KafkaProducerActorImpl.IsAggregateStateCurrent("baz", Instant.now.minusSeconds(1L))
-      val stillWaitingProbe = TestProbe()
-      val isStateCurrentMsg3 = KafkaProducerActorImpl.IsAggregateStateCurrent("foo", Instant.now.plusSeconds(10L))
-
-      val newState = empty
-        .addInFlight(exampleMetadata)
-        .addPendingInitialization(upToDateProbe.ref, isStateCurrentMsg)
-        .addPendingInitialization(expiredProbe.ref, isStateCurrentMsg2)
-        .addPendingInitialization(stillWaitingProbe.ref, isStateCurrentMsg3)
-
-      val expectedPendingInit = KafkaProducerActorImpl.PendingInitialization(upToDateProbe.ref, isStateCurrentMsg.aggregateId, isStateCurrentMsg.expirationTime)
-      val expectedPendingInit2 =
-        KafkaProducerActorImpl.PendingInitialization(expiredProbe.ref, isStateCurrentMsg2.aggregateId, isStateCurrentMsg2.expirationTime)
-      val expectedPendingInit3 =
-        KafkaProducerActorImpl.PendingInitialization(stillWaitingProbe.ref, isStateCurrentMsg3.aggregateId, isStateCurrentMsg3.expirationTime)
-      newState.pendingInitializations should contain allElementsOf Seq(expectedPendingInit, expectedPendingInit2, expectedPendingInit3)
-
-      val barRecordPartitionMeta = KTableProgressUpdate(
-        topicPartition = new TopicPartition(barRecord1.wrapped.topic(), barRecord1.wrapped.partition()),
-        lagInfo = LagInfo(barRecord1.wrapped.offset(), barRecord2.wrapped.offset()))
-      val processedState = newState.processedUpTo(barRecordPartitionMeta)
-      processedState.pendingInitializations should contain only expectedPendingInit3
-
-      upToDateProbe.expectMsg(true)
-      expiredProbe.expectMsg(false)
-      stillWaitingProbe.expectNoMessage()
     }
 
     "Calculate how long a transaction has been in progress for" in {


### PR DESCRIPTION
In the PublisherActor, we handle `IsAggregateUpToDate` messages a handful of ways depending on current state. If the aggregate is fully up to date in the KTable, we reply with a `true` immediately. If not initialized or waiting for the KTable to index, we stash. If there are records in flight for the aggregate that are not in the KTable, we add the aggregate actor to a list of "pending initializations" so that we can reply immediately when the state becomes up to date.  In practice, we almost never hit the case where keeping pending initializations around actually saves us some time. In cases where the KTable indexing takes a long time all the stashing of these can also get a bit excessive.

This PR removes pending initializations and updates the behavior to the following.

### In the `uninitialized` or `waitingForKTableIndexing` states

Reply to `IsAggregateUpToDate` messages immediately with `false`.

This avoids the stash and gives the aggregate actor a clear response rather than letting the ask time out if it isn't unstashed in time. The PersistentActor retries initializing anyways. The tradeoff here is in the healthy case if a message immediately comes into a service it may be delayed a few seconds while the producer actor transitions to running and the aggregate actor is forced to retry initialization. We could potentially look at lowering the retry time in these cases to reduce that overhead, but it's pretty minor.

### In the `processing` state

Reply to `IsAggregateUpToDate` messages immediately with either `true` (if nothing is in flight for that aggregate) or `false` (if things are in flight). Remove the `pendingInitializations` concept entirely.

This simplifies some of the actor logic since we'll no longer need to track pending initializations. Additionally, explicit replies back to the aggregate actor rather than ask timeouts sitting in the stash or pending initializations list makes it more clear to the aggregate actor what's going on.

The impact of this from a performance standpoint should be very minimal. An aggregate actor will only send the `IsAggregateUpToDate` message to the producer when it is not in memory already, which only happens if the actor crashes or passivates. In the case of passivating, unless the KTable is extremely far behind there's a very high chance all of the aggregates published messages have been indexed to the KTable long before it attempts to passivate. In the case of actor crashes and quick restarts, the pending initializations may actually help initialize a tiny bit faster.  However, this slight improvement in initialization time for that particular edge case is probably not worth the extra complexity and bookkeeping required of the KafkaPublisher for that purpose.