### PR TITLE
Use local actor ref provider for health signal actor system

### DIFF
--- a/modules/common/src/main/resources/reference.conf
+++ b/modules/common/src/main/resources/reference.conf
@@ -112,11 +112,11 @@ surge {
     # Amount of time to wait when sending a command to an aggregate before considering it to have timed out.
     ask-timeout = 30 seconds
     ask-timeout = ${?STATE_STORE_ACTOR_ASK_TIMEOUT}
-    fetch-state-retry-interval = 3 seconds
+    fetch-state-retry-interval = 2 seconds
     fetch-state-rety-interval = ${?STATE_FETCH_INTERVAL}
-    initialize-state-retry-interval = 250 milliseconds
+    initialize-state-retry-interval = 500 milliseconds
     initialize-state-retry-interval = ${?STATE_INIT_RETRY_INTERVAL}
-    max-initialization-attempts = 5
+    max-initialization-attempts = 10
     max-initialization-attempts = ${?STATE_MAX_INIT_ATTEMPTS}
     backoff {
       min-backoff = 3 seconds

--- a/modules/common/src/main/scala/surge/internal/health/HealthSignalBus.scala
+++ b/modules/common/src/main/scala/surge/internal/health/HealthSignalBus.scala
@@ -3,8 +3,7 @@
 package surge.internal.health
 
 import java.util.regex.Pattern
-
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.actor.{ Actor, ActorRef, ActorSystem, BootstrapSetup, Props, ProviderSelection }
 import akka.event.LookupClassification
 import akka.pattern._
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -23,7 +22,7 @@ import scala.util.Try
 case class SubscriberInfo(name: String, id: String)
 
 object HealthSignalBus {
-  implicit val system: ActorSystem = ActorSystem("HealthSignalBusActorSystem")
+  implicit val system: ActorSystem = ActorSystem.create("HealthSignalBusActorSystem", BootstrapSetup().withActorRefProvider(ProviderSelection.local()))
   val log: Logger = LoggerFactory.getLogger(getClass)
 
   val config: Config = ConfigFactory.load().getConfig("surge.health")
@@ -122,7 +121,7 @@ private class EmittableHealthSignalImpl(healthSignal: HealthSignal, signalBus: H
 
 private[surge] class HealthSignalBusImpl(config: HealthSignalBusConfig, signalStreamSupplier: HealthSignalStreamProvider, stopStreamOnUnsubscribe: Boolean)
     extends HealthSignalBusInternal {
-  implicit val actorSystem: ActorSystem = ActorSystem("healthSignalBusActorSystem")
+  implicit val actorSystem: ActorSystem = ActorSystem.create("healthSignalBusActorSystem", BootstrapSetup().withActorRefProvider(ProviderSelection.local()))
 
   private lazy val stream: HealthSignalStream = signalStreamSupplier.provide(bus = this).subscribe()
   private var supervisorRef: Option[HealthSupervisorActorRef] = None


### PR DESCRIPTION
When configuring remoting with a static port the health signal actor system and regular Surge actor system currently attempt to bind to the same port, which results in errors.  The health signal actor system doesn't need remoting and can be local.