### PR TITLE
Wire Config object to various components to allow for runtime overrides of settings

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -5,6 +5,7 @@ package surge.core
 import akka.actor.{ ActorRef, ActorSystem, PoisonPill, Props }
 import akka.pattern._
 import akka.util.Timeout
+import com.typesafe.config.Config
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.Headers
 import org.slf4j.LoggerFactory
@@ -32,6 +33,7 @@ object KafkaProducerActor {
       kStreams: AggregateStateStoreKafkaStreams[_],
       partitionTracker: KafkaConsumerPartitionAssignmentTracker,
       signalBus: HealthSignalBusTrait,
+      config: Config,
       kafkaProducerOverride: Option[KafkaBytesProducer] = None): KafkaProducerActor = {
 
     val kafkaProducerProps = Props(
@@ -42,6 +44,7 @@ object KafkaProducerActor {
         kStreams = kStreams,
         partitionTracker = partitionTracker,
         signalBus = signalBus,
+        config = config,
         kafkaProducerOverride = kafkaProducerOverride)).withDispatcher(dispatcherName)
 
     new KafkaProducerActor(

--- a/modules/command-engine/core/src/main/scala/surge/core/SurgePartitionRouter.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/SurgePartitionRouter.scala
@@ -3,6 +3,7 @@
 package surge.core
 
 import akka.actor._
+import com.typesafe.config.Config
 import surge.health.HealthSignalBusTrait
 import surge.internal.SurgeModel
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
@@ -16,11 +17,12 @@ trait SurgePartitionRouter extends HealthyComponent with Controllable {
 
 object SurgePartitionRouter {
   def apply(
+      config: Config,
       system: ActorSystem,
       partitionTracker: KafkaConsumerPartitionAssignmentTracker,
       businessLogic: SurgeModel[_, _, _, _],
       regionCreator: PersistentActorRegionCreator[String],
       signalBus: HealthSignalBusTrait): SurgePartitionRouter = {
-    new SurgePartitionRouterImpl(system, partitionTracker, businessLogic, regionCreator, signalBus)
+    new SurgePartitionRouterImpl(config, system, partitionTracker, businessLogic, regionCreator, signalBus)
   }
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeGenericBusinessLogicTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeGenericBusinessLogicTrait.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.global
 
 trait SurgeGenericBusinessLogicTrait[AggId, Agg, Command, Rej, Event] {
 
-  protected val config: Config = ConfigFactory.load()
+  def config: Config = ConfigFactory.load()
 
   def aggregateName: String
 

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -3,10 +3,10 @@
 package surge.internal.core
 
 import java.util.regex.Pattern
-
 import akka.actor._
 import akka.pattern.ask
 import akka.util.Timeout
+import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import surge.core.{ Ack, Controllable, SurgePartitionRouter }
 import surge.health.HealthSignalBusTrait
@@ -23,6 +23,7 @@ import scala.languageFeature.postfixOps
 import scala.util.{ Failure, Success, Try }
 
 private[surge] final class SurgePartitionRouterImpl(
+    config: Config,
     system: ActorSystem,
     partitionTracker: KafkaConsumerPartitionAssignmentTracker,
     businessLogic: SurgeModel[_, _, _, _],
@@ -35,6 +36,7 @@ private[surge] final class SurgePartitionRouterImpl(
   private val log = LoggerFactory.getLogger(getClass)
 
   private val shardRouterProps = KafkaPartitionShardRouterActor.props(
+    config,
     partitionTracker,
     businessLogic.partitioner,
     businessLogic.kafka.stateTopic,

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
@@ -11,7 +11,6 @@ import surge.health.{ HealthSignalBusAware, HealthSignalBusTrait }
 import surge.internal.SurgeModel
 import surge.internal.akka.cluster.ActorSystemHostAwareness
 import surge.internal.akka.kafka.{ CustomConsumerGroupRebalanceListener, KafkaConsumerPartitionAssignmentTracker, KafkaConsumerStateTrackingActor }
-import surge.internal.core.SurgePartitionRouterImpl
 import surge.internal.health.HealthSignalStreamProvider
 import surge.internal.persistence.PersistentActorRegionCreator
 import surge.kafka.PartitionAssignments
@@ -58,16 +57,15 @@ private[surge] abstract class SurgeMessagePipeline[S, M, +R, E](
     clientId = businessLogic.kafka.clientId,
     system = system,
     metrics = businessLogic.metrics,
-    signalBus = signalBus)
+    signalBus = signalBus,
+    config = config)
 
   protected val cqrsRegionCreator: PersistentActorRegionCreator[M] =
     new PersistentActorRegionCreator[M](actorSystem, businessLogic, kafkaStreamsImpl, partitionTracker, businessLogic.metrics, signalBus, config = config)
 
-  protected val actorRouter: SurgePartitionRouter = SurgePartitionRouter(actorSystem, partitionTracker, businessLogic, cqrsRegionCreator, signalBus)
+  protected val actorRouter: SurgePartitionRouter = SurgePartitionRouter(config, actorSystem, partitionTracker, businessLogic, cqrsRegionCreator, signalBus)
 
   protected val surgeHealthCheck: SurgeHealthCheck = new SurgeHealthCheck(businessLogic.aggregateName, kafkaStreamsImpl, actorRouter)(ExecutionContext.global)
-  protected def createPartitionRouter(): SurgePartitionRouter =
-    new SurgePartitionRouterImpl(actorSystem, partitionTracker, businessLogic, cqrsRegionCreator, signalBus)
 
   override def healthCheck(): Future[HealthCheck] = {
     surgeHealthCheck.healthCheck()

--- a/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
@@ -5,7 +5,7 @@ package surge.internal.kafka
 import akka.actor.{ ActorRef, NoSerializationVerificationNeeded, Stash, Status, Timers }
 import akka.pattern._
 import akka.util.Timeout
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import io.opentelemetry.api.trace.Tracer
 import org.apache.kafka.clients.producer.{ ProducerConfig, ProducerRecord }
 import org.apache.kafka.common.TopicPartition
@@ -74,7 +74,7 @@ class KafkaProducerActorImpl(
     kStreams: AggregateStateStoreKafkaStreams[_],
     partitionTracker: KafkaConsumerPartitionAssignmentTracker,
     override val signalBus: HealthSignalBusTrait,
-    config: Config = ConfigFactory.load(),
+    config: Config,
     kafkaProducerOverride: Option[KafkaBytesProducer] = None)
     extends ActorWithTracing
     with ActorHostAwareness
@@ -142,7 +142,7 @@ class KafkaProducerActorImpl(
 
     // Set up the producer on the events topic so the partitioner can partition automatically on the events topic since we manually set the partition for the
     // aggregate state topic record and the events topic could have a different number of partitions
-    val producer = KafkaBytesProducer(brokers, eventsTopicOpt.getOrElse(PoisonTopic), partitioner, kafkaConfig)
+    val producer = KafkaBytesProducer(config, brokers, eventsTopicOpt.getOrElse(PoisonTopic), partitioner, kafkaConfig)
     if (enableMetrics) {
       metrics.registerKafkaMetrics(kafkaPublisherMetricsName, () => producer.producer.metrics)
     }

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/KTableInitializationSupport.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/KTableInitializationSupport.scala
@@ -29,11 +29,13 @@ trait KTableInitializationSupport[Model] {
   def kafkaStreamsCommand: AggregateStateStoreKafkaStreams[_]
   def deserializeState(bytes: Array[Byte]): Option[Model]
 
+  def retryConfig: RetryConfig
+
   def onInitializationFailed(cause: Throwable): Unit
   def onInitializationSuccess(model: Option[Model]): Unit
 
   protected def initializeState(initializationAttempts: Int, retryCause: Option[Throwable])(implicit ec: ExecutionContext): Unit = {
-    if (initializationAttempts > RetryConfig.AggregateActor.maxInitializationAttempts) {
+    if (initializationAttempts > retryConfig.AggregateActor.maxInitializationAttempts) {
       val reasonForFailure = retryCause.getOrElse(new RuntimeException(s"Aggregate $aggregateId could not be initialized"))
       onInitializationFailed(reasonForFailure)
     } else {
@@ -43,14 +45,14 @@ trait KTableInitializationSupport[Model] {
           if (isStateCurrent) {
             fetchState(initializationAttempts)
           } else {
-            val retryIn = RetryConfig.AggregateActor.initializeStateInterval
+            val retryIn = retryConfig.AggregateActor.initializeStateInterval
             log.warn("State for {} is not up to date in Kafka streams, retrying initialization in {}", Seq(aggregateId, retryIn): _*)
             val failureReason = AggregateStateNotCurrentInKTableException(aggregateId, kafkaProducerActor.assignedPartition)
             context.system.scheduler.scheduleOnce(retryIn)(initializeState(initializationAttempts + 1, Some(failureReason)))
           }
         }
         .recover { case exception =>
-          val retryIn = RetryConfig.AggregateActor.fetchStateRetryInterval
+          val retryIn = retryConfig.AggregateActor.fetchStateRetryInterval
           log.error(s"Failed to check if $aggregateName aggregate was up to date for id $aggregateId, retrying in $retryIn", exception)
           val failureReason = AggregateStateNotCurrentInKTableException(aggregateId, kafkaProducerActor.assignedPartition)
           context.system.scheduler.scheduleOnce(retryIn)(initializeState(initializationAttempts + 1, Some(failureReason)))
@@ -71,7 +73,7 @@ trait KTableInitializationSupport[Model] {
         onInitializationSuccess(stateOpt)
       }
       .recover { case exception =>
-        val retryIn = RetryConfig.AggregateActor.fetchStateRetryInterval
+        val retryIn = retryConfig.AggregateActor.fetchStateRetryInterval
         log.error(s"Failed to initialize $aggregateName actor for aggregate $aggregateId, retrying in $retryIn", exception)
         val failureReason = AggregateInitializationException(aggregateId, exception)
         context.system.scheduler.scheduleOnce(retryIn)(initializeState(initializationAttempts + 1, Some(failureReason)))

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/KTablePersistenceSupport.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/KTablePersistenceSupport.scala
@@ -33,8 +33,7 @@ trait KTablePersistenceSupport[Agg, Event] {
   protected def onPersistenceFailure(state: ActorState, cause: Throwable): Unit
 
   private val log = LoggerFactory.getLogger(getClass)
-  private val config = ConfigFactory.load()
-  private val maxProducerFailureRetries: Int = config.getInt("surge.aggregate-actor.publish-failure-max-retries")
+  protected val maxProducerFailureRetries: Int
 
   private sealed trait Internal extends NoSerializationVerificationNeeded
   private case class PersistenceSuccess(newState: ActorState, startTime: Instant) extends Internal

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/PersistentActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/PersistentActor.scala
@@ -137,7 +137,7 @@ class PersistentActor[S, M, R, E](
     val businessLogic: SurgeModel[S, M, R, E],
     val regionSharedResources: PersistentEntitySharedResources,
     val signalBus: HealthSignalBusTrait,
-    implicit val config: Config)
+    config: Config)
     extends ActorWithTracing
     with Stash
     with KTablePersistenceSupport[S, E]
@@ -179,11 +179,15 @@ class PersistentActor[S, M, R, E](
 
   override def deserializeState(bytes: Array[Byte]): Option[S] = businessLogic.aggregateReadFormatting.readState(bytes)
 
+  override def retryConfig: RetryConfig = new RetryConfig(config)
+
   override val tracer: Tracer = businessLogic.tracer
 
   override val aggregateName: String = businessLogic.aggregateName
 
   protected val receiveTimeout: FiniteDuration = TimeoutConfig.AggregateActor.idleTimeout
+
+  override protected val maxProducerFailureRetries: Int = config.getInt("surge.aggregate-actor.publish-failure-max-retries")
 
   protected val log: Logger = LoggerFactory.getLogger(getClass)
 
@@ -333,7 +337,7 @@ class PersistentActor[S, M, R, E](
   }
 
   def onInitializationFailed(cause: Throwable): Unit = {
-    log.error(s"Could not initialize actor for $aggregateId after ${RetryConfig.AggregateActor.maxInitializationAttempts} attempts.  Stopping actor")
+    log.error(s"Could not initialize actor for $aggregateId after ${retryConfig.AggregateActor.maxInitializationAttempts} attempts.  Stopping actor")
     context.become(initializationFailed(ACKError(cause)))
     unstashAll() // Handle any pending messages before stopping so we can reply with an explicit error instead of timing out
     self ! Stop

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/PersistentActorRegion.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/PersistentActorRegion.scala
@@ -54,7 +54,8 @@ class PersistentActorRegion[M](
     businessLogic = businessLogic,
     partitionTracker = partitionTracker,
     kStreams = aggregateKafkaStreamsImpl,
-    signalBus = signalBus)
+    signalBus = signalBus,
+    config = config)
 
   override def onShardTerminated(): Unit = {
     log.debug("Shard for partition {} terminated, killing partition kafkaProducerActor", assignedPartition)

--- a/modules/command-engine/core/src/test/scala/surge/internal/domain/SurgeMessagePipelineSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/domain/SurgeMessagePipelineSpec.scala
@@ -5,7 +5,7 @@ package surge.internal.domain
 import java.util.regex.Pattern
 import akka.actor.ActorSystem
 import akka.testkit.{ TestKit, TestProbe }
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.ConfigFactory
 import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 import org.apache.kafka.streams.KafkaStreams
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
@@ -46,6 +46,7 @@ class SurgeMessagePipelineSpec
     PatienceConfig(timeout = scaled(Span(30, Seconds)), interval = scaled(Span(10, Milliseconds)))
 
   private val config: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = 6001)
+  private val defaultConfig = ConfigFactory.load()
 
   case class TestContext(
       probe: TestProbe,
@@ -76,7 +77,7 @@ class SurgeMessagePipelineSpec
           .toMatcher))
 
     // Create SurgeMessagePipeline
-    val pipeline = createPipeline(signalStreamProvider, config)
+    val pipeline = createPipeline(signalStreamProvider)
     // Start Pipeline
     pipeline.start().futureValue shouldBe an[Ack]
 
@@ -294,14 +295,13 @@ class SurgeMessagePipelineSpec
     newValueObj.string == "state" + newValueObj.int
   }
 
-  private def createPipeline(
-      signalStreamProvider: SlidingHealthSignalStreamProvider,
-      config: Config): SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent] = {
-    new SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent](system, businessLogic, signalStreamProvider, config) {
+  private def createPipeline(signalStreamProvider: SlidingHealthSignalStreamProvider): SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent] = {
+    new SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent](system, businessLogic, signalStreamProvider, defaultConfig) {
       override def actorSystem: ActorSystem = system
 
       override protected val actorRouter: SurgePartitionRouterImpl =
         new SurgePartitionRouterImpl(
+          defaultConfig,
           actorSystem,
           new KafkaConsumerPartitionAssignmentTracker(stateChangeActor),
           businessLogic,
@@ -317,7 +317,8 @@ class SurgeMessagePipelineSpec
         clientId = businessLogic.kafka.clientId,
         signalStreamProvider.bus(),
         system,
-        Metrics.globalMetricRegistry)
+        Metrics.globalMetricRegistry,
+        defaultConfig)
 
       override def shutdownSignalPatterns(): Seq[Pattern] = Seq(Pattern.compile("kafka.streams.fatal.retries.exceeded.error"))
     }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommand.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommand.scala
@@ -2,10 +2,8 @@
 
 package surge.javadsl.command
 
-import java.util.concurrent.CompletionStage
-
 import akka.actor.ActorSystem
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import surge.core
 import surge.core.command._
 import surge.core.commondsl.{ SurgeCommandBusinessLogicTrait, SurgeRejectableCommandBusinessLogicTrait }
@@ -17,6 +15,7 @@ import surge.internal.health.windows.stream.sliding.SlidingHealthSignalStreamPro
 import surge.javadsl.common.{ HealthCheck, HealthCheckTrait }
 import surge.metrics.Metric
 
+import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
@@ -31,8 +30,7 @@ object SurgeCommand {
   def create[AggId, Agg, Command, Evt](
       businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Evt]): SurgeCommand[AggId, Agg, Command, Nothing, Evt] = {
     val actorSystem = ActorSystem(s"${businessLogic.aggregateName}ActorSystem")
-    val config = ConfigFactory.load()
-    create(actorSystem, businessLogic, config)
+    create(actorSystem, businessLogic, businessLogic.config)
   }
 
   def create[AggId, Agg, Command, Evt](
@@ -42,7 +40,7 @@ object SurgeCommand {
     new SurgeCommandImpl(
       actorSystem,
       SurgeCommandModel(businessLogic),
-      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
+      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(config), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
       businessLogic.aggregateIdToString,
       config)
   }
@@ -54,7 +52,7 @@ object SurgeCommand {
     new SurgeCommandImpl(
       actorSystem,
       SurgeCommandModel(businessLogic),
-      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
+      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(config), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
       businessLogic.aggregateIdToString,
       config)
   }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/SurgeCommand.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/SurgeCommand.scala
@@ -3,7 +3,7 @@
 package surge.scaladsl.command
 
 import akka.actor.ActorSystem
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import surge.core
 import surge.core.command.SurgeCommandModel
 import surge.core.commondsl.{ SurgeCommandBusinessLogicTrait, SurgeRejectableCommandBusinessLogicTrait }
@@ -25,17 +25,16 @@ object SurgeCommand {
   def apply[AggId, Agg, Command, Event](
       businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event]): SurgeCommand[AggId, Agg, Command, Nothing, Event] = {
     val actorSystem = ActorSystem(s"${businessLogic.aggregateName}ActorSystem")
-    val config = ConfigFactory.load()
-    apply(actorSystem, businessLogic, config)
+    apply(actorSystem, businessLogic, businessLogic.config)
   }
   def apply[AggId, Agg, Command, Event](
       actorSystem: ActorSystem,
       businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event],
-      config: Config = ConfigFactory.load()): SurgeCommand[AggId, Agg, Command, Nothing, Event] = {
+      config: Config): SurgeCommand[AggId, Agg, Command, Nothing, Event] = {
     new SurgeCommandImpl(
       actorSystem,
       SurgeCommandModel(businessLogic),
-      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
+      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(config), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
       businessLogic.aggregateIdToString,
       config)
   }
@@ -47,7 +46,7 @@ object SurgeCommand {
     new SurgeCommandImpl(
       actorSystem,
       SurgeCommandModel(businessLogic),
-      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
+      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(config), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
       businessLogic.aggregateIdToString,
       config)
   }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/SurgeEvent.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/SurgeEvent.scala
@@ -3,7 +3,7 @@
 package surge.scaladsl.event
 
 import akka.actor.ActorSystem
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import surge.core
 import surge.core.event.SurgeEventServiceModel
 import surge.health.config.WindowingStreamConfigLoader
@@ -23,13 +23,15 @@ trait SurgeEvent[AggId, Agg, Evt] extends core.SurgeProcessingTrait[Agg, Nothing
 object SurgeEvent {
   def create[AggId, Agg, Evt](businessLogic: SurgeEventBusinessLogic[AggId, Agg, Evt]): SurgeEvent[AggId, Agg, Evt] = {
     val actorSystem = ActorSystem(s"${businessLogic.aggregateName}ActorSystem")
-    val config = ConfigFactory.load()
     new SurgeEventImpl(
       actorSystem,
       SurgeEventServiceModel.apply(businessLogic),
-      new SlidingHealthSignalStreamProvider(WindowingStreamConfigLoader.load(), actorSystem, filters = SignalPatternMatcherRegistry.load().toSeq),
+      new SlidingHealthSignalStreamProvider(
+        WindowingStreamConfigLoader.load(businessLogic.config),
+        actorSystem,
+        filters = SignalPatternMatcherRegistry.load().toSeq),
       businessLogic.aggregateIdToString,
-      config)
+      businessLogic.config)
   }
 
 }

--- a/modules/common/src/main/scala/surge/health/config/WindowingStreamConfig.scala
+++ b/modules/common/src/main/scala/surge/health/config/WindowingStreamConfig.scala
@@ -67,22 +67,17 @@ object WindowingStreamSliderConfigLoader extends WindowingStreamAdvancerConfigLo
 }
 
 object WindowingStreamConfigLoader {
-  private val config = ConfigFactory.load().getConfig("surge.health.window.stream")
-
   def load(config: Config): WindowingStreamConfig = {
-    val maxDelay = config.getDuration("delay").toMillis.millis
-    val maxStreamSize = config.getInt("max-size")
-    val frequencies = config.getDurationList("frequencies").asScala.map(d => d.toMillis.millis)
+    val windowStreamConfig = config.getConfig("surge.health.window.stream")
+    val maxDelay = windowStreamConfig.getDuration("delay").toMillis.millis
+    val maxStreamSize = windowStreamConfig.getInt("max-size")
+    val frequencies = windowStreamConfig.getDurationList("frequencies").asScala.map(d => d.toMillis.millis)
 
-    val throttleConfig = config.getConfig("throttle")
+    val throttleConfig = windowStreamConfig.getConfig("throttle")
     val windowStreamThrottleConfig = ThrottleConfig(throttleConfig.getInt("elements"), throttleConfig.getDuration("duration").toMillis.millis)
-    val advancerConfig = config.getConfig("advancer")
+    val advancerConfig = windowStreamConfig.getConfig("advancer")
     val windowStreamAdvancerConfig = WindowingStreamAdvancerConfigLoader(advancerConfig.getString("type")).load(advancerConfig)
 
     WindowingStreamConfig(maxDelay, maxStreamSize, frequencies.toSeq, windowStreamThrottleConfig, windowStreamAdvancerConfig)
-  }
-
-  def load(): WindowingStreamConfig = {
-    load(config)
   }
 }

--- a/modules/common/src/main/scala/surge/internal/akka/kafka/AkkaKafkaConsumer.scala
+++ b/modules/common/src/main/scala/surge/internal/akka/kafka/AkkaKafkaConsumer.scala
@@ -3,10 +3,9 @@
 package surge.internal.akka.kafka
 
 import java.util.Properties
-
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerSettings
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.IsolationLevel
 import org.apache.kafka.common.serialization.Deserializer
@@ -14,13 +13,8 @@ import surge.kafka.KafkaSecurityConfiguration
 
 import scala.jdk.CollectionConverters._
 
-object AkkaKafkaConsumer extends KafkaSecurityConfiguration {
-  private val config: Config = ConfigFactory.load()
-  private val defaultBrokers = config.getString("kafka.brokers")
-  private val consumerSessionTimeout = config.getDuration("surge.kafka-event-source.consumer.session-timeout")
-  private val autoOffsetReset = config.getString("surge.kafka-event-source.consumer.auto-offset-reset")
-
-  def consumerSettings[Key, Value](actorSystem: ActorSystem, groupId: String, brokers: String = defaultBrokers)(
+class AkkaKafkaConsumer(override val config: Config) extends KafkaSecurityConfiguration {
+  def consumerSettings[Key, Value](actorSystem: ActorSystem, groupId: String, brokers: String, autoOffsetReset: String)(
       implicit keyDeserializer: Deserializer[Key],
       valueDeserializer: Deserializer[Value]): ConsumerSettings[Key, Value] = {
 
@@ -34,7 +28,6 @@ object AkkaKafkaConsumer extends KafkaSecurityConfiguration {
       .withGroupId(groupId)
       .withProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.toString.toLowerCase)
       .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset.toLowerCase)
-      .withProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, consumerSessionTimeout.toMillis.toString)
       .withProperties(securityProps.asScala.toMap)
   }
 }

--- a/modules/common/src/main/scala/surge/internal/config/RetryConfig.scala
+++ b/modules/common/src/main/scala/surge/internal/config/RetryConfig.scala
@@ -2,14 +2,12 @@
 
 package surge.internal.config
 
+import com.typesafe.config.Config
+
 import java.util.concurrent.TimeUnit
-
-import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.duration._
 
-object RetryConfig {
-  private val config = ConfigFactory.load()
+class RetryConfig(config: Config) {
 
   object AggregateActor {
     val fetchStateRetryInterval: FiniteDuration =

--- a/modules/common/src/main/scala/surge/internal/health/windows/WindowSlider.scala
+++ b/modules/common/src/main/scala/surge/internal/health/windows/WindowSlider.scala
@@ -2,25 +2,18 @@
 
 package surge.internal.health.windows
 
-import java.time.Instant
-
-import com.typesafe.config.{ Config, ConfigFactory }
 import surge.health.domain.HealthSignal
 import surge.health.windows.Window
 
+import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
-import scala.util.Try
 
 trait WindowSlider extends Slider[Window] {
   override def slide(it: Window, amount: Int = 1, force: Boolean = false): Option[Window]
 }
 
 object WindowSlider {
-  val config: Config = ConfigFactory.load()
-  private val configuredSlideAmount: Int = Try { config.getInt("surge.health.window.stream.slider.amount") }.getOrElse(1)
-  private val configuredBufferSize: Int = Try { config.getInt("surge.health.window.stream.slider.buffer") }.getOrElse(10)
-
-  def apply(slideAmount: Int = configuredSlideAmount, bufferSize: Int = configuredBufferSize): WindowSlider =
+  def apply(slideAmount: Int, bufferSize: Int): WindowSlider =
     new WindowSliderImpl(slideAmount, bufferSize)
 }
 

--- a/modules/common/src/main/scala/surge/internal/streams/ManagedDataPipeline.scala
+++ b/modules/common/src/main/scala/surge/internal/streams/ManagedDataPipeline.scala
@@ -4,7 +4,6 @@ package surge.internal.streams
 
 import java.util.UUID
 
-import com.typesafe.config.ConfigFactory
 import surge.metrics.Metrics
 import surge.streams.DataPipeline
 import surge.streams.DataPipeline.ReplayResult
@@ -13,10 +12,9 @@ import surge.streams.replay.ReplayControl
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 
-private[surge] class ManagedDataPipeline[Key, Value](underlyingManager: KafkaStreamManager[Key, Value], metrics: Metrics) extends DataPipeline {
+private[surge] class ManagedDataPipeline[Key, Value](underlyingManager: KafkaStreamManager[Key, Value], metrics: Metrics, enableMetrics: Boolean)
+    extends DataPipeline {
   private val kafkaConsumerMetricsName: String = s"kafka-consumer-metrics-${UUID.randomUUID()}"
-  private val config = ConfigFactory.load()
-  private val enableMetrics = config.getBoolean("surge.kafka-event-source.enable-kafka-metrics")
   override def stop(): Unit = {
     if (enableMetrics) {
       metrics.unregisterKafkaMetric(kafkaConsumerMetricsName)

--- a/modules/common/src/main/scala/surge/internal/streams/StreamManager.scala
+++ b/modules/common/src/main/scala/surge/internal/streams/StreamManager.scala
@@ -10,7 +10,7 @@ import akka.pattern._
 import akka.stream.scaladsl.{ Flow, RestartSource, Sink }
 import akka.util.Timeout
 import akka.{ Done, NotUsed }
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
 import io.opentelemetry.api.trace.Tracer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.Deserializer
@@ -24,7 +24,6 @@ import surge.streams.DataPipeline._
 import surge.streams.replay.{ EventReplaySettings, EventReplayStrategy, ReplayControl, ReplayControlContext }
 import surge.streams.{ EventPlusStreamMeta, KafkaStreamMeta }
 
-import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
@@ -32,14 +31,15 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.util.Try
 
 object PartitionAssignorConfig {
-  private val config = ConfigFactory.load()
   private val log = LoggerFactory.getLogger(getClass)
-  val assignorClassName: String = config.getString("surge.kafka-event-source.consumer.partition-assignor").toLowerCase() match {
-    case "range"              => classOf[HostAwareRangeAssignor].getName
-    case "cooperative-sticky" => classOf[HostAwareCooperativeStickyAssignor].getName
-    case other =>
-      log.warn("Attempted to use an unknown range assignor named [{}], accepted values are [range, cooperative-sticky].  Defaulting to range.", other)
-      classOf[HostAwareRangeAssignor].getName
+  def assignorClassName(config: Config): String = {
+    config.getString("surge.kafka-event-source.consumer.partition-assignor").toLowerCase() match {
+      case "range"              => classOf[HostAwareRangeAssignor].getName
+      case "cooperative-sticky" => classOf[HostAwareCooperativeStickyAssignor].getName
+      case other =>
+        log.warn("Attempted to use an unknown range assignor named [{}], accepted values are [range, cooperative-sticky].  Defaulting to range.", other)
+        classOf[HostAwareRangeAssignor].getName
+    }
   }
 }
 
@@ -83,15 +83,15 @@ class KafkaStreamManager[Key, Value](
     valueDeserializer: Deserializer[Value],
     replayStrategy: EventReplayStrategy,
     replaySettings: EventReplaySettings,
-    val tracer: Tracer)(implicit val actorSystem: ActorSystem)
+    val tracer: Tracer,
+    config: Config)(implicit val actorSystem: ActorSystem)
     extends ActorSystemHostAwareness
     with Logging {
 
-  private val config = ConfigFactory.load()
   private val metricFetchTimeout = config.getDuration("surge.kafka-event-source.kafka-metric-fetch-timeout").toMillis.milliseconds
   private val consumerGroup = consumerSettings.getProperty(ConsumerConfig.GROUP_ID_CONFIG)
   private val actorRegistry = new ActorRegistry(actorSystem)
-  private val managerActor = actorSystem.actorOf(Props(new KafkaStreamManagerActor(topicName, subscriptionProvider, tracer, actorRegistry)))
+  private val managerActor = actorSystem.actorOf(Props(new KafkaStreamManagerActor(config, topicName, subscriptionProvider, tracer, actorRegistry)))
 
   private val deserializeKey: Array[Byte] => Key = { bytes => keyDeserializer.deserialize(topicName, bytes) }
   private val deserializeValue: Array[Byte] => Value = { bytes => valueDeserializer.deserialize(topicName, bytes) }
@@ -158,6 +158,7 @@ object KafkaStreamManagerActor {
 }
 
 class KafkaStreamManagerActor[Key, Value](
+    config: Config,
     topicName: String,
     subscriptionProvider: KafkaSubscriptionProvider[Key, Value],
     val tracer: Tracer,
@@ -170,10 +171,8 @@ class KafkaStreamManagerActor[Key, Value](
   import KafkaStreamManagerActor._
   import context.{ dispatcher, system }
 
-  private val config = ConfigFactory.load()
-  private val reuseConsumerId = config.getBoolean("surge.kafka-reuse-consumer-id")
   // Set this uniquely per manager actor so that restarts of the Kafka stream don't cause a rebalance of the consumer group
-  private val clientId = s"surge-event-source-managed-consumer-${UUID.randomUUID()}"
+  private val clientId = subscriptionProvider.clientId
 
   private val backoffMin = config.getDuration("surge.kafka-event-source.backoff.min").toMillis.millis
   private val backoffMax = config.getDuration("surge.kafka-event-source.backoff.max").toMillis.millis

--- a/modules/common/src/main/scala/surge/kafka/KafkaAdminClient.scala
+++ b/modules/common/src/main/scala/surge/kafka/KafkaAdminClient.scala
@@ -2,8 +2,9 @@
 
 package surge.kafka
 
-import java.util.Properties
+import com.typesafe.config.Config
 
+import java.util.Properties
 import org.apache.kafka.clients.admin.{ Admin, ListOffsetsOptions, OffsetSpec }
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo
 import org.apache.kafka.clients.consumer.{ ConsumerConfig, OffsetAndMetadata }
@@ -15,11 +16,11 @@ case class LagInfo(currentOffsetPosition: Long, endOffsetPosition: Long) {
   val offsetLag: Long = Math.max(0, endOffsetPosition - currentOffsetPosition)
 }
 
-object KafkaAdminClient extends KafkaSecurityConfiguration {
-  def apply(brokers: Seq[String]): KafkaAdminClient = {
+object KafkaAdminClient {
+  def apply(config: Config, brokers: Seq[String]): KafkaAdminClient = {
     val p = new Properties()
     p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers.mkString(","))
-    configureSecurityProperties(p)
+    new KafkaSecurityConfigurationImpl(config).configureSecurityProperties(p)
     apply(p)
   }
 
@@ -28,7 +29,7 @@ object KafkaAdminClient extends KafkaSecurityConfiguration {
   }
 }
 
-class KafkaAdminClient(props: Properties) extends KafkaSecurityConfiguration {
+class KafkaAdminClient(props: Properties) {
   private val client = Admin.create(props)
 
   def consumerGroupOffsets(groupName: String): Map[TopicPartition, OffsetAndMetadata] = {

--- a/modules/common/src/main/scala/surge/kafka/KafkaConsumer.scala
+++ b/modules/common/src/main/scala/surge/kafka/KafkaConsumer.scala
@@ -2,10 +2,11 @@
 
 package surge.kafka
 
+import com.typesafe.config.Config
+
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{ ExecutorService, Executors }
-
 import org.apache.kafka.clients.consumer.{ ConsumerConfig, ConsumerRecord, KafkaConsumer }
 import org.apache.kafka.common.serialization.{ ByteArrayDeserializer, StringDeserializer }
 import org.apache.kafka.common.{ PartitionInfo, TopicPartition }
@@ -99,7 +100,11 @@ abstract class KafkaConsumerTrait[K, V] extends KafkaSecurityConfiguration {
   }
 }
 
-final case class KafkaStringConsumer(override val brokers: Seq[String], override val consumerConfig: UltiKafkaConsumerConfig, kafkaConfig: Map[String, String])
+final case class KafkaStringConsumer(
+    override val config: Config,
+    override val brokers: Seq[String],
+    override val consumerConfig: UltiKafkaConsumerConfig,
+    kafkaConfig: Map[String, String])
     extends KafkaConsumerTrait[String, String] {
   val props: Properties = {
     val p = defaultProps
@@ -111,7 +116,11 @@ final case class KafkaStringConsumer(override val brokers: Seq[String], override
   override val consumer: KafkaConsumer[String, String] = new KafkaConsumer[String, String](props)
 }
 
-final case class KafkaBytesConsumer(override val brokers: Seq[String], override val consumerConfig: UltiKafkaConsumerConfig, kafkaConfig: Map[String, String])
+final case class KafkaBytesConsumer(
+    override val config: Config,
+    override val brokers: Seq[String],
+    override val consumerConfig: UltiKafkaConsumerConfig,
+    kafkaConfig: Map[String, String])
     extends KafkaConsumerTrait[String, Array[Byte]] {
   val props: Properties = {
     val p = defaultProps

--- a/modules/common/src/main/scala/surge/kafka/KafkaProducer.scala
+++ b/modules/common/src/main/scala/surge/kafka/KafkaProducer.scala
@@ -2,8 +2,9 @@
 
 package surge.kafka
 
-import java.util.Properties
+import com.typesafe.config.{ Config, ConfigFactory }
 
+import java.util.Properties
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.TopicPartition
@@ -130,10 +131,11 @@ trait KafkaProducerTrait[K, V] extends KafkaSecurityConfiguration with KafkaProd
 
 object KafkaStringProducer {
   def create(brokers: java.util.Collection[String], topic: KafkaTopic): KafkaStringProducer = {
-    KafkaStringProducer(brokers.asScala.toSeq, topic)
+    KafkaStringProducer(ConfigFactory.load(), brokers.asScala.toSeq, topic)
   }
 }
 case class KafkaStringProducer(
+    override val config: Config,
     brokers: Seq[String],
     override val topic: KafkaTopic,
     override val partitioner: KafkaPartitionerBase[String] = NoPartitioner[String],
@@ -153,6 +155,7 @@ case class KafkaStringProducer(
 }
 
 case class KafkaBytesProducer(
+    override val config: Config,
     brokers: Seq[String],
     override val topic: KafkaTopicTrait,
     override val partitioner: KafkaPartitionerBase[String] = NoPartitioner[String],

--- a/modules/common/src/main/scala/surge/kafka/KafkaSecurityConfiguration.scala
+++ b/modules/common/src/main/scala/surge/kafka/KafkaSecurityConfiguration.scala
@@ -3,13 +3,13 @@
 package surge.kafka
 
 import java.util.Properties
-
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.common.config.{ SaslConfigs, SslConfigs }
 
 trait KafkaSecurityConfiguration {
-  private val config = ConfigFactory.load()
+  protected def config: Config
+
   private def setIfDefined(props: Properties, key: String, configLocation: String): Unit = {
     if (config.hasPath(configLocation)) {
       val configValue = config.getString(configLocation)
@@ -34,4 +34,8 @@ trait KafkaSecurityConfiguration {
   }
 }
 
-object KafkaSecurityConfiguration extends KafkaSecurityConfiguration
+object KafkaSecurityConfiguration extends KafkaSecurityConfiguration {
+  override val config: Config = ConfigFactory.load()
+}
+
+private[surge] class KafkaSecurityConfigurationImpl(override val config: Config) extends KafkaSecurityConfiguration

--- a/modules/common/src/main/scala/surge/kafka/javadsl/KafkaProducer.scala
+++ b/modules/common/src/main/scala/surge/kafka/javadsl/KafkaProducer.scala
@@ -2,9 +2,10 @@
 
 package surge.kafka.javadsl
 
+import com.typesafe.config.{ Config, ConfigFactory }
+
 import java.util.concurrent.CompletionStage
 import java.util.{ Optional, Properties }
-
 import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata }
 import org.apache.kafka.common.serialization.{ ByteArraySerializer, StringSerializer }
 import surge.kafka.{ KafkaPartitionerBase, KafkaProducerHelperCommon, KafkaSecurityConfiguration, KafkaTopic, PartitionStringUpToColon }
@@ -35,17 +36,19 @@ abstract class AbstractKafkaProducer[K, V] extends KafkaSecurityConfiguration wi
 }
 
 object KafkaBytesProducer {
+  private val config = ConfigFactory.load()
   def create(brokers: java.util.Collection[String], topic: KafkaTopic): KafkaBytesProducer = {
-    new KafkaBytesProducer(brokers, topic, PartitionStringUpToColon, Map.empty[String, String].asJava)
+    new KafkaBytesProducer(brokers, topic, PartitionStringUpToColon, config, Map.empty[String, String].asJava)
   }
   def create(brokers: java.util.Collection[String], topic: KafkaTopic, kafkaConfig: java.util.Map[String, String]): KafkaBytesProducer = {
-    new KafkaBytesProducer(brokers, topic, PartitionStringUpToColon, kafkaConfig)
+    new KafkaBytesProducer(brokers, topic, PartitionStringUpToColon, config, kafkaConfig)
   }
 }
 class KafkaBytesProducer(
     brokers: java.util.Collection[String],
     override val topic: KafkaTopic,
     override val partitioner: KafkaPartitionerBase[String],
+    override val config: Config,
     kafkaConfig: java.util.Map[String, String])
     extends AbstractKafkaProducer[String, Array[Byte]] {
   val props: Properties = {

--- a/modules/common/src/main/scala/surge/kafka/streams/KafkaStreamLifeCycleManagement.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/KafkaStreamLifeCycleManagement.scala
@@ -3,10 +3,7 @@
 package surge.kafka.streams
 
 import akka.actor.{ Actor, Stash }
-import com.typesafe.config.ConfigFactory
-import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.streams.{ KafkaStreams, StreamsConfig }
-import surge.internal.config.TimeoutConfig
 import surge.internal.utils.{ InlineReceive, Logging }
 import surge.kafka.streams.HealthyActor.GetHealth
 import surge.kafka.streams.KafkaStreamLifeCycleManagement._
@@ -25,10 +22,9 @@ trait KafkaStreamLifeCycleManagement[K, V, T <: KafkaStreamsConsumer[K, V], SV] 
 
   protected val streamsConfig: Map[String, String]
   protected val metrics: Metrics
+  protected val enableMetrics: Boolean
 
   private val streamsMetricName = s"kafka-streams-${settings.applicationId}-${settings.storeName}"
-  private val config = ConfigFactory.load()
-  private val enableMetrics = config.getBoolean("surge.kafka-streams.enable-kafka-metrics")
 
   /**
    * Base configuration for all streams, extend as needed Ex: override val streamsConfig = baseStreamsConfig ++ Map[String, String](... stream specific config

--- a/modules/common/src/main/scala/surge/kafka/streams/KafkaStreamsConsumer.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/KafkaStreamsConsumer.scala
@@ -2,10 +2,11 @@
 
 package surge.kafka.streams
 
+import com.typesafe.config.Config
+
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.Properties
-
 import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala._
@@ -54,6 +55,7 @@ abstract class KafkaStreamsConsumer[K, V](implicit keySerde: Serde[K], valueSerd
 }
 
 case class GenericKafkaStreamsConsumer[Value](
+    override val config: Config,
     brokers: Seq[String],
     applicationId: String,
     kafkaConfig: Map[String, String],
@@ -62,6 +64,7 @@ case class GenericKafkaStreamsConsumer[Value](
     extends KafkaStreamsConsumer[String, Value]
 
 case class KafkaStringStreamsConsumer(
+    override val config: Config,
     brokers: Seq[String],
     applicationId: String,
     kafkaConfig: Map[String, String],
@@ -70,6 +73,7 @@ case class KafkaStringStreamsConsumer(
     extends KafkaStreamsConsumer[String, String]
 
 case class KafkaByteStreamsConsumer(
+    override val config: Config,
     brokers: Seq[String],
     applicationId: String,
     kafkaConfig: Map[String, String],

--- a/modules/common/src/main/scala/surge/kafka/streams/SurgeKafkaStreamsPersistencePlugin.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/SurgeKafkaStreamsPersistencePlugin.scala
@@ -2,7 +2,7 @@
 
 package surge.kafka.streams
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier
 import org.apache.kafka.streams.state.internals.RocksDbKeyValueBytesStoreSupplier
 import org.slf4j.LoggerFactory
@@ -23,12 +23,12 @@ class RocksDBPersistencePlugin extends SurgeKafkaStreamsPersistencePlugin {
 
 object SurgeKafkaStreamsPersistencePluginLoader {
   private val log = LoggerFactory.getLogger(getClass)
-  private val config = ConfigFactory.load()
-  private val persistencePluginName = config.getString("surge.kafka-streams.state-store-plugin")
   private val defaultPersistencePluginName = "rocksdb"
   private lazy val defaultPersistencePlugin = new RocksDBPersistencePlugin
 
-  def load(): SurgeKafkaStreamsPersistencePlugin = {
+  def load(config: Config): SurgeKafkaStreamsPersistencePlugin = {
+    val persistencePluginName = config.getString("surge.kafka-streams.state-store-plugin")
+
     Try(config.getString(s"$persistencePluginName.plugin-class")) match {
       case Failure(_) =>
         log.error(

--- a/modules/common/src/main/scala/surge/streams/DataSource.scala
+++ b/modules/common/src/main/scala/surge/streams/DataSource.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem
 import akka.kafka.{ AutoSubscription, ConsumerSettings, Subscriptions }
 import com.typesafe.config.{ Config, ConfigFactory }
 import io.opentelemetry.api.trace.Tracer
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.Deserializer
 import surge.internal.akka.kafka.AkkaKafkaConsumer
 import surge.internal.streams.{ KafkaOffsetManagementSubscriptionProvider, KafkaStreamManager, ManagedDataPipeline, ManualOffsetManagementSubscriptionProvider }
@@ -25,8 +26,8 @@ trait DataSource[Key, Value] {
 }
 
 trait KafkaDataSource[Key, Value] extends DataSource[Key, Value] {
-  private val config: Config = ConfigFactory.load()
-  private val defaultBrokers = config.getString("kafka.brokers")
+  protected val config: Config = ConfigFactory.load()
+  private lazy val defaultBrokers = config.getString("kafka.brokers")
 
   def kafkaBrokers: String = defaultBrokers
   def kafkaTopic: KafkaTopic
@@ -50,8 +51,14 @@ trait KafkaDataSource[Key, Value] extends DataSource[Key, Value] {
   }
 
   def to(sink: DataHandler[Key, Value], consumerGroup: String, autoStart: Boolean): DataPipeline = {
-    val consumerSettings = AkkaKafkaConsumer
-      .consumerSettings[Key, Value](actorSystem, groupId = consumerGroup, brokers = kafkaBrokers)(keyDeserializer, valueDeserializer)
+    val consumerSessionTimeout = config.getDuration("surge.kafka-event-source.consumer.session-timeout")
+    val autoOffsetReset = config.getString("surge.kafka-event-source.consumer.auto-offset-reset")
+
+    val consumerSettings = new AkkaKafkaConsumer(config)
+      .consumerSettings[Key, Value](actorSystem, groupId = consumerGroup, brokers = kafkaBrokers, autoOffsetReset = autoOffsetReset)(
+        keyDeserializer,
+        valueDeserializer)
+      .withProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, consumerSessionTimeout.toMillis.toString)
       .withProperties(additionalKafkaProperties.asScala.toMap)
     to(consumerSettings)(sink, autoStart)
   }
@@ -61,9 +68,9 @@ trait KafkaDataSource[Key, Value] extends DataSource[Key, Value] {
     val topicName = kafkaTopic.name
     val subscriptionProvider = offsetManager match {
       case _: DefaultKafkaOffsetManager =>
-        new KafkaOffsetManagementSubscriptionProvider[Key, Value](topicName, subscription, consumerSettings, sink)
+        new KafkaOffsetManagementSubscriptionProvider[Key, Value](config, topicName, subscription, consumerSettings, sink)
       case _ =>
-        new ManualOffsetManagementSubscriptionProvider[Key, Value](topicName, subscription, consumerSettings, sink, offsetManager)
+        new ManualOffsetManagementSubscriptionProvider[Key, Value](config, topicName, subscription, consumerSettings, sink, offsetManager)
     }
     new KafkaStreamManager[Key, Value](
       topicName = topicName,
@@ -73,13 +80,15 @@ trait KafkaDataSource[Key, Value] extends DataSource[Key, Value] {
       valueDeserializer = valueDeserializer,
       replayStrategy = replayStrategy,
       replaySettings = replaySettings,
-      tracer = tracer)
+      tracer = tracer,
+      config = config)
   }
 
   private[streams] def to(consumerSettings: ConsumerSettings[Key, Value])(sink: DataHandler[Key, Value], autoStart: Boolean): DataPipeline = {
     implicit val system: ActorSystem = actorSystem
     implicit val executionContext: ExecutionContext = ExecutionContext.global
-    val pipeline = new ManagedDataPipeline(getStreamManager(consumerSettings, sink), metrics)
+    val enableMetrics = config.getBoolean("surge.kafka-event-source.enable-kafka-metrics")
+    val pipeline = new ManagedDataPipeline(getStreamManager(consumerSettings, sink), metrics, enableMetrics)
     if (autoStart) {
       pipeline.start()
     }

--- a/modules/common/src/multi-jvm/scala/surge/internal/streams/StreamManagerMultiJvmSpec.scala
+++ b/modules/common/src/multi-jvm/scala/surge/internal/streams/StreamManagerMultiJvmSpec.scala
@@ -59,6 +59,7 @@ class StreamManagerSpecBase
     with OptionValues {
   import StreamManagerSpecConfig._
 
+  private val defaultConfig = ConfigFactory.load()
   val tracer: Tracer = NoopTracerFactory.create()
   override def initialParticipants: Int = roles.size
 
@@ -82,7 +83,7 @@ class StreamManagerSpecBase
           }
       }
       val embeddedBroker = s"${node(node0).address.host.getOrElse("localhost")}:${config.kafkaPort}"
-      val consumerSettings = AkkaKafkaConsumer.consumerSettings[String, Array[Byte]](system, "replay-test").withBootstrapServers(embeddedBroker)
+      val consumerSettings = new AkkaKafkaConsumer(defaultConfig).consumerSettings[String, Array[Byte]](system, "replay-test", embeddedBroker, "earliest")
 
       runOn(node0) {
         withRunningKafka {
@@ -93,12 +94,12 @@ class StreamManagerSpecBase
             enterBarrier("afterReplay")
             ()
           }
-          val replaySettings = KafkaForeverReplaySettings(topic.name).copy(brokers = List(embeddedBroker))
+          val replaySettings = KafkaForeverReplaySettings(defaultConfig, topic.name).copy(brokers = List(embeddedBroker))
           val kafkaForeverReplayStrategy = KafkaForeverReplayStrategy.create(actorSystem = system, settings = replaySettings, postReplay = postReplayDef)
 
           val probe = TestProbe()
           val subscriptionProvider =
-            new KafkaOffsetManagementSubscriptionProvider(topic.name, Subscriptions.topics(topic.name), consumerSettings, sendToTestProbe(probe))
+            new KafkaOffsetManagementSubscriptionProvider(defaultConfig, topic.name, Subscriptions.topics(topic.name), consumerSettings, sendToTestProbe(probe))
           val consumer = new KafkaStreamManager(
             topicName = topic.name,
             consumerSettings = consumerSettings,
@@ -107,7 +108,8 @@ class StreamManagerSpecBase
             valueDeserializer = new ByteArrayDeserializer,
             replayStrategy = kafkaForeverReplayStrategy,
             replaySettings = replaySettings,
-            tracer = tracer)
+            tracer = tracer,
+            config = ConfigFactory.load())
 
           consumer.start()
           probe.expectMsgAnyOf(20.seconds, record1, record2)
@@ -119,7 +121,7 @@ class StreamManagerSpecBase
       runOn(node1) {
         val probe = TestProbe()
         val subscriptionProvider =
-          new KafkaOffsetManagementSubscriptionProvider(topic.name, Subscriptions.topics(topic.name), consumerSettings, sendToTestProbe(probe))
+          new KafkaOffsetManagementSubscriptionProvider(defaultConfig, topic.name, Subscriptions.topics(topic.name), consumerSettings, sendToTestProbe(probe))
         val consumer = new KafkaStreamManager(
           topicName = topic.name,
           consumerSettings = consumerSettings,
@@ -128,7 +130,8 @@ class StreamManagerSpecBase
           valueDeserializer = new ByteArrayDeserializer,
           replayStrategy = new NoOpEventReplayStrategy,
           replaySettings = DefaultEventReplaySettings,
-          tracer = tracer)
+          tracer = tracer,
+          config = ConfigFactory.load())
 
         consumer.start()
         probe.expectMsgAnyOf(20.seconds, record1, record2)

--- a/modules/common/src/test/scala/surge/health/config/WindowingStreamConfigLoaderSpec.scala
+++ b/modules/common/src/test/scala/surge/health/config/WindowingStreamConfigLoaderSpec.scala
@@ -11,7 +11,7 @@ class WindowingStreamConfigLoaderSpec extends AnyWordSpec with Matchers {
 
   "WindowingStreamConfig" should {
     "load" in {
-      val config = ConfigFactory.load("windowing-stream-config-loader-spec").getConfig("surge.health.window.stream")
+      val config = ConfigFactory.load("windowing-stream-config-loader-spec")
 
       val windowingStreamConfig = WindowingStreamConfigLoader.load(config)
 

--- a/modules/common/src/test/scala/surge/internal/health/windows/actor/HealthSignalWindowActorSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/health/windows/actor/HealthSignalWindowActorSpec.scala
@@ -148,7 +148,7 @@ class HealthSignalWindowActorSpec
           actorSystem = system,
           initialWindowProcessingDelay = 10.milliseconds,
           windowFrequency = 100.milliseconds,
-          advancer = WindowSlider(1),
+          advancer = WindowSlider(1, 10),
           windowCheckInterval = 10.milliseconds)
 
       val probe = TestProbe()

--- a/modules/common/src/test/scala/surge/internal/streams/KafkaSubscriptionProviderSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/streams/KafkaSubscriptionProviderSpec.scala
@@ -7,6 +7,7 @@ import akka.kafka.Subscriptions
 import akka.stream.scaladsl.{ Flow, Sink }
 import akka.testkit.{ TestKit, TestProbe }
 import akka.{ Done, NotUsed }
+import com.typesafe.config.ConfigFactory
 import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
@@ -44,6 +45,8 @@ class KafkaSubscriptionProviderSpec
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(100, Millis))
 
+  private val defaultConfig = ConfigFactory.load()
+
   private class InMemoryOffsetManager() extends OffsetManager {
     private val offsetMappings: scala.collection.mutable.Map[TopicPartition, Long] = scala.collection.mutable.Map.empty
 
@@ -61,14 +64,14 @@ class KafkaSubscriptionProviderSpec
       groupId: String,
       businessLogic: (String, Array[Byte]) => Future[_],
       offsetManager: OffsetManager): ManualOffsetManagementSubscriptionProvider[String, Array[Byte]] = {
-    val consumerSettings = AkkaKafkaConsumer.consumerSettings[String, Array[Byte]](system, groupId).withBootstrapServers(kafkaBrokers)
+    val consumerSettings = new AkkaKafkaConsumer(defaultConfig).consumerSettings[String, Array[Byte]](system, groupId, kafkaBrokers, "earliest")
     val tupleFlow: (String, Array[Byte], Map[String, Array[Byte]]) => Future[_] = { (k, v, _) => businessLogic(k, v) }
     val partitionBy: (String, Array[Byte], Map[String, Array[Byte]]) => String = { (k, _, _) => k }
     val businessFlow = new DataHandler[String, Array[Byte]] {
       override def dataHandler[Meta]: Flow[EventPlusStreamMeta[String, Array[Byte], Meta], Meta, NotUsed] =
         FlowConverter.flowFor[String, Array[Byte], Meta](tupleFlow, partitionBy, new DefaultDataSinkExceptionHandler, 16)
     }
-    new ManualOffsetManagementSubscriptionProvider(topic.name, Subscriptions.topics(topic.name), consumerSettings, businessFlow, offsetManager)
+    new ManualOffsetManagementSubscriptionProvider(defaultConfig, topic.name, Subscriptions.topics(topic.name), consumerSettings, businessFlow, offsetManager)
   }
 
   private def sendToTestProbe(testProbe: TestProbe)(key: String, value: Array[Byte]): Future[Done] = {

--- a/modules/common/src/test/scala/surge/internal/streams/StreamManagerSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/streams/StreamManagerSpec.scala
@@ -7,6 +7,7 @@ import akka.kafka.Subscriptions
 import akka.stream.scaladsl.Flow
 import akka.testkit.{ TestKit, TestProbe }
 import akka.{ Done, NotUsed }
+import com.typesafe.config.ConfigFactory
 import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{ Deserializer, Serializer }
@@ -44,6 +45,8 @@ class StreamManagerSpec
   private implicit val stringDeserializer: Deserializer[String] = DefaultSerdes.stringSerde.deserializer()
   private implicit val byteArrayDeserializer: Deserializer[Array[Byte]] = DefaultSerdes.byteArraySerde.deserializer()
 
+  private val defaultConfig = ConfigFactory.load()
+
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
@@ -61,7 +64,7 @@ class StreamManagerSpec
       businessLogic: (String, Array[Byte]) => Future[_],
       replayStrategy: EventReplayStrategy = new NoOpEventReplayStrategy,
       replaySettings: EventReplaySettings = DefaultEventReplaySettings): KafkaStreamManager[String, Array[Byte]] = {
-    val consumerSettings = AkkaKafkaConsumer.consumerSettings[String, Array[Byte]](system, groupId).withBootstrapServers(kafkaBrokers)
+    val consumerSettings = new AkkaKafkaConsumer(defaultConfig).consumerSettings[String, Array[Byte]](system, groupId, kafkaBrokers, "earliest")
 
     val parallelism = 16
     val tupleFlow: (String, Array[Byte], Map[String, Array[Byte]]) => Future[_] = { (k, v, _) => businessLogic(k, v) }
@@ -70,7 +73,8 @@ class StreamManagerSpec
       override def dataHandler[Meta]: Flow[EventPlusStreamMeta[String, Array[Byte], Meta], Meta, NotUsed] =
         FlowConverter.flowFor[String, Array[Byte], Meta](tupleFlow, partitionBy, new DefaultDataSinkExceptionHandler, parallelism)
     }
-    val subscriptionProvider = new KafkaOffsetManagementSubscriptionProvider(topic.name, Subscriptions.topics(topic.name), consumerSettings, businessFlow)
+    val subscriptionProvider =
+      new KafkaOffsetManagementSubscriptionProvider(defaultConfig, topic.name, Subscriptions.topics(topic.name), consumerSettings, businessFlow)
     new KafkaStreamManager(
       topic.name,
       consumerSettings,
@@ -79,7 +83,8 @@ class StreamManagerSpec
       byteArrayDeserializer,
       replayStrategy,
       replaySettings,
-      NoopTracerFactory.create())
+      NoopTracerFactory.create(),
+      defaultConfig)
   }
 
   "StreamManager" should {
@@ -226,7 +231,7 @@ class StreamManagerSpec
         publishToKafka(new ProducerRecord[String, String](topic.name, 1, record2, record2))
         publishToKafka(new ProducerRecord[String, String](topic.name, 2, record3, record3))
 
-        val settings = KafkaForeverReplaySettings(topic.name).copy(brokers = List(embeddedBroker))
+        val settings = KafkaForeverReplaySettings(defaultConfig, topic.name).copy(brokers = List(embeddedBroker))
         val kafkaForeverReplayStrategy = KafkaForeverReplayStrategy.create[String, Array[Byte]](system, settings)
         val consumer =
           testStreamManager(topic, kafkaBrokers = embeddedBroker, groupId = "replay-test", sendToTestProbe(probe), kafkaForeverReplayStrategy, settings)

--- a/modules/common/src/test/scala/surge/kafka/KafkaAdminClientSpec.scala
+++ b/modules/common/src/test/scala/surge/kafka/KafkaAdminClientSpec.scala
@@ -2,6 +2,7 @@
 
 package surge.kafka
 
+import com.typesafe.config.ConfigFactory
 import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
@@ -15,6 +16,8 @@ class KafkaAdminClientSpec extends AnyWordSpec with Matchers with EmbeddedKafka 
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(10, Millis)))
 
+  private val defaultConfig = ConfigFactory.load()
+
   "KafkaAdminClient" should {
     "Correctly calculate consumer lag" in {
       withRunningKafkaOnFoundPort(EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)) { implicit actualConfig =>
@@ -25,10 +28,10 @@ class KafkaAdminClientSpec extends AnyWordSpec with Matchers with EmbeddedKafka 
         val partition1 = new TopicPartition(topic.name, 1)
         val partition2 = new TopicPartition(topic.name, 2)
         val embeddedBroker = s"localhost:${actualConfig.kafkaPort}"
-        val client = KafkaAdminClient(Seq(embeddedBroker))
+        val client = KafkaAdminClient(defaultConfig, Seq(embeddedBroker))
 
         val consumerGroupName = "test-consumer-group"
-        val consumer = KafkaStringConsumer(Seq(embeddedBroker), UltiKafkaConsumerConfig(consumerGroupName), Map.empty).consumer
+        val consumer = KafkaStringConsumer(defaultConfig, Seq(embeddedBroker), UltiKafkaConsumerConfig(consumerGroupName), Map.empty).consumer
         consumer.subscribe(java.util.Arrays.asList(topic.name))
 
         publishToKafka(new ProducerRecord[String, String](topic.name, 0, "", "initial value"))

--- a/modules/common/src/test/scala/surge/kafka/KafkaPartitionShardRouterActorSpec.scala
+++ b/modules/common/src/test/scala/surge/kafka/KafkaPartitionShardRouterActorSpec.scala
@@ -4,6 +4,7 @@ package surge.kafka
 
 import akka.actor.{ Actor, ActorContext, ActorSystem, DeadLetter, Props }
 import akka.testkit.{ TestKit, TestProbe }
+import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.TopicPartition
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.when
@@ -60,6 +61,8 @@ trait KafkaPartitionShardRouterActorSpecLike extends MockitoSugar {
 
   implicit val system: ActorSystem
 
+  private val defaultConfig = ConfigFactory.load()
+
   val partitionAssignments: Map[HostPort, List[TopicPartition]]
   private val tracer = NoopTracerFactory.create()
   private val trackedTopic = KafkaTopic("test")
@@ -89,6 +92,7 @@ trait KafkaPartitionShardRouterActorSpecLike extends MockitoSugar {
     }
     val shardRouterProps = Props(
       new KafkaPartitionShardRouterActor(
+        config = defaultConfig,
         partitionTracker = new KafkaConsumerPartitionAssignmentTracker(partitionProbe.ref),
         kafkaStateProducer = producer,
         regionCreator = new ProbeInterceptorRegionCreator(regionProbe),

--- a/modules/common/src/test/scala/surge/kafka/KafkaProducerSpec.scala
+++ b/modules/common/src/test/scala/surge/kafka/KafkaProducerSpec.scala
@@ -2,9 +2,10 @@
 
 package surge.kafka
 
+import com.typesafe.config.{ Config, ConfigFactory }
+
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
-
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.internals.{ RecordHeader, RecordHeaders }
@@ -15,7 +16,10 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class KafkaProducerSpec extends AnyWordSpec with Matchers {
+  private val defaultConfig = ConfigFactory.load()
+
   class MockProducer(val producer: KafkaProducer[String, String]) extends KafkaProducerTrait[String, String] {
+    override protected def config: Config = defaultConfig
     override def topic: KafkaTopic = KafkaTopic("")
     override def partitioner: KafkaPartitionerBase[String] = NoPartitioner[String]
   }
@@ -25,7 +29,7 @@ class KafkaProducerSpec extends AnyWordSpec with Matchers {
   "KafkaProducer" should {
     "Configure correctly" in {
       val acksConfigOverride = Map(ProducerConfig.ACKS_CONFIG -> "1")
-      val producer = KafkaBytesProducer(Seq("localhost:9092"), KafkaTopic("test"), kafkaConfig = acksConfigOverride)
+      val producer = KafkaBytesProducer(defaultConfig, Seq("localhost:9092"), KafkaTopic("test"), kafkaConfig = acksConfigOverride)
 
       val props = producer.props
       props.getProperty(ProducerConfig.ACKS_CONFIG) shouldEqual "1"

--- a/modules/common/src/test/scala/surge/kafka/streams/AggregateStateStoreKafkaStreamsSpec.scala
+++ b/modules/common/src/test/scala/surge/kafka/streams/AggregateStateStoreKafkaStreamsSpec.scala
@@ -3,9 +3,9 @@
 package surge.kafka.streams
 
 import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
 import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.kafka.streams.{ KafkaStreams, TopologyTestDriver }
@@ -61,6 +61,8 @@ class AggregateStateStoreKafkaStreamsSpec
   }
   val config: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
 
+  private val defaultConfig = ConfigFactory.load()
+
   "AggregateStateStoreKafkaStreams" should {
     def assertStoreKeyValue(
         testDriver: TopologyTestDriver,
@@ -106,9 +108,10 @@ class AggregateStateStoreKafkaStreamsSpec
           clientId = "",
           testHealthSignalStreamProvider(Seq.empty).bus(),
           system,
-          Metrics.globalMetricRegistry) {
+          Metrics.globalMetricRegistry,
+          defaultConfig) {
           override lazy val settings: AggregateStateStoreKafkaStreamsImplSettings =
-            AggregateStateStoreKafkaStreamsImplSettings(appId, testAggregateName, "").copy(brokers = Seq(s"localhost:${actualConfig.kafkaPort}"))
+            AggregateStateStoreKafkaStreamsImplSettings(defaultConfig, appId, testAggregateName, "").copy(brokers = Seq(s"localhost:${actualConfig.kafkaPort}"))
         }
 
         aggStoreKafkaStreams.start()
@@ -147,9 +150,10 @@ class AggregateStateStoreKafkaStreamsSpec
           clientId = "",
           testHealthSignalStreamProvider(Seq.empty).bus(),
           system,
-          Metrics.globalMetricRegistry) {
+          Metrics.globalMetricRegistry,
+          defaultConfig) {
           override lazy val settings: AggregateStateStoreKafkaStreamsImplSettings =
-            AggregateStateStoreKafkaStreamsImplSettings(appId, testAggregateName, "").copy(brokers = Seq(s"localhost:${actualConfig.kafkaPort}"))
+            AggregateStateStoreKafkaStreamsImplSettings(defaultConfig, appId, testAggregateName, "").copy(brokers = Seq(s"localhost:${actualConfig.kafkaPort}"))
         }
 
         aggStoreKafkaStreams.start()

--- a/modules/common/src/test/scala/surge/streams/KafkaEventSourceSpec.scala
+++ b/modules/common/src/test/scala/surge/streams/KafkaEventSourceSpec.scala
@@ -7,6 +7,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.kafka.ConsumerSettings
 import akka.testkit.{ TestKit, TestProbe }
+import com.typesafe.config.ConfigFactory
 import io.opentelemetry.api.trace.Tracer
 import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -36,6 +37,8 @@ class KafkaEventSourceSpec
     with Eventually
     with BeforeAndAfterAll {
 
+  private val defaultConfig = ConfigFactory.load()
+
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
@@ -60,8 +63,8 @@ class KafkaEventSourceSpec
   }
 
   private def testConsumerSettings(kafkaBrokers: String, groupId: String): ConsumerSettings[String, Array[Byte]] = {
-    AkkaKafkaConsumer
-      .consumerSettings[String, Array[Byte]](system, groupId)
+    new AkkaKafkaConsumer(defaultConfig)
+      .consumerSettings[String, Array[Byte]](system, groupId, kafkaBrokers, "earliest")
       .withBootstrapServers(kafkaBrokers)
       .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
   }

--- a/modules/metrics/src/main/scala/surge/metrics/Metric.scala
+++ b/modules/metrics/src/main/scala/surge/metrics/Metric.scala
@@ -2,7 +2,7 @@
 
 package surge.metrics
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 
 trait MetricValueProvider {
@@ -41,9 +41,10 @@ case class Metric(info: MetricInfo, level: RecordingLevel, valueProvider: Metric
 }
 
 object MetricsConfig {
-  private val config = ConfigFactory.load()
-  private val configRecordingLevel = RecordingLevel.fromString(config.getString("metrics.recording-level"))
-  def fromConfig: MetricsConfig = MetricsConfig(recordingLevel = configRecordingLevel)
+  def fromConfig(config: Config): MetricsConfig = {
+    val configRecordingLevel = RecordingLevel.fromString(config.getString("metrics.recording-level"))
+    MetricsConfig(recordingLevel = configRecordingLevel)
+  }
 }
 case class MetricsConfig(recordingLevel: RecordingLevel)
 

--- a/modules/metrics/src/main/scala/surge/metrics/Metrics.scala
+++ b/modules/metrics/src/main/scala/surge/metrics/Metrics.scala
@@ -2,8 +2,9 @@
 
 package surge.metrics
 
-import java.util.function.Supplier
+import com.typesafe.config.ConfigFactory
 
+import java.util.function.Supplier
 import org.apache.kafka.common.MetricName
 import org.slf4j.LoggerFactory
 import surge.metrics.statistics.{ Count, ExponentiallyWeightedMovingAverage, MostRecentValue, RateHistogram }
@@ -12,7 +13,7 @@ import scala.collection.mutable
 import scala.concurrent.duration._
 
 object Metrics {
-  lazy val globalMetricRegistry: Metrics = Metrics(config = MetricsConfig.fromConfig)
+  lazy val globalMetricRegistry: Metrics = Metrics(config = MetricsConfig.fromConfig(ConfigFactory.load()))
 }
 
 object KafkaMetricListener {

--- a/modules/metrics/src/test/scala/surge/metrics/MetricsSpec.scala
+++ b/modules/metrics/src/test/scala/surge/metrics/MetricsSpec.scala
@@ -81,8 +81,8 @@ class MetricsSpec extends AnyWordSpec with Matchers with MockitoSugar {
     }
 
     "Not allow duplicate metrics to be registered" in {
-      val testMetric = Metric(MetricInfo("test", "test"), RecordingLevel.Info, new Max, MetricsConfig.fromConfig)
-      val metrics = new Metrics(MetricsConfig.fromConfig)
+      val testMetric = Metric(MetricInfo("test", "test"), RecordingLevel.Info, new Max, MetricsConfig(RecordingLevel.Info))
+      val metrics = new Metrics(MetricsConfig(RecordingLevel.Info))
 
       metrics.registerMetric(testMetric)
       an[IllegalArgumentException] should be thrownBy metrics.registerMetric(testMetric)

--- a/modules/metrics/src/test/scala/surge/metrics/MetricsSpecLike.scala
+++ b/modules/metrics/src/test/scala/surge/metrics/MetricsSpecLike.scala
@@ -11,7 +11,7 @@ object MetricsSpecLike {
   }
 }
 trait MetricsSpecLike extends AnyWordSpecLike with Matchers {
-  protected val metrics = new Metrics(MetricsConfig.fromConfig)
+  protected val metrics = new Metrics(MetricsConfig(RecordingLevel.Info))
 
   protected def metricValue(metricName: String): Double = {
     MetricsSpecLike.metricValue(metrics, metricName)


### PR DESCRIPTION
Rather than calling `ConfigFactory.load()` to statically load configuration on the internals, wire a `Config` from the outer layers of Surge into the internals so that the config used can be overridden in more flexible ways.