### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/surge-ci.yml
+++ b/.github/workflows/surge-ci.yml
@@ -25,3 +25,5 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: build docs
+        run: 'sbt surge-docs/clean surge-docs/makeSite'

--- a/modules/surge-docs/src/main/paradox/index.md
+++ b/modules/surge-docs/src/main/paradox/index.md
@@ -5,6 +5,7 @@
 * [Overview](overview.md)
 * [Command Service](command-usage.md)
 * [Open Tracing Integration](tracing-usage.md)
+* [Repository Tour](repository-tour.md)
 
 @@@
 


### PR DESCRIPTION
Fixes paradox build and adds a task to the PR validation workflow to validate that it can build properly.