### PR TITLE
Allow configuring Kafka producer max-request-size

### DIFF
--- a/modules/command-engine/core/src/main/resources/reference.conf
+++ b/modules/command-engine/core/src/main/resources/reference.conf
@@ -32,6 +32,9 @@ kafka {
     transaction-timeout-ms = 60000
     transaction-timeout-ms = ${?KAFKA_PUBLISHER_TRANSACTION_TIMEOUT_MS}
 
+    max-request-size = 1048576
+    max-request-size = ${?KAFKA_PUBLISHER_MAX_REQUEST_SIZE}
+
     ktable-check-interval = 500 milliseconds
     ktable-check-interval = ${?KAFKA_PUBLISHER_INITIALIZATION_INTERVAL}
 

--- a/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
@@ -92,6 +92,7 @@ class KafkaProducerActorImpl(
   private val assignedTopicPartitionKey = s"${assignedPartition.topic}:${assignedPartition.partition}"
   private val flushInterval = config.getDuration("kafka.publisher.flush-interval", TimeUnit.MILLISECONDS).milliseconds
   private val publisherBatchSize = config.getInt("kafka.publisher.batch-size")
+  private val publisherMaxRequestSize = config.getInt("kafka.publisher.max-request-size")
   private val publisherLingerMs = config.getInt("kafka.publisher.linger-ms")
   private val publisherCompression = config.getString("kafka.publisher.compression-type")
   private val publisherTransactionTimeoutMs = config.getString("kafka.publisher.transaction-timeout-ms")
@@ -135,6 +136,7 @@ class KafkaProducerActorImpl(
     val kafkaConfig = Map[String, String](
       ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG -> true.toString,
       ProducerConfig.BATCH_SIZE_CONFIG -> publisherBatchSize.toString,
+      ProducerConfig.MAX_REQUEST_SIZE_CONFIG -> publisherMaxRequestSize.toString,
       ProducerConfig.LINGER_MS_CONFIG -> publisherLingerMs.toString,
       ProducerConfig.COMPRESSION_TYPE_CONFIG -> publisherCompression,
       ProducerConfig.TRANSACTION_TIMEOUT_CONFIG -> publisherTransactionTimeoutMs,


### PR DESCRIPTION
Allow overriding Kafka producer `max.request.size` property for services whose messages are larger than the 1Mb default.