### PR TITLE
Add onDeserializationFailure handler function to KafkaEventSource

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -18,7 +18,7 @@ object MiMa extends AutoPlugin {
 
   private def previousArtifacts(projectName: String, organization: String): Set[sbt.ModuleID] = {
     val versions: Seq[String] = {
-      val firstPatchVersion = "4"
+      val firstPatchVersion = "19"
       Seq(s"0.5.$firstPatchVersion")
     }
 


### PR DESCRIPTION
Adds back the `onDeserializationFailure` handler function in the EventSource to allow for custom handling of deserialization failures depending on the consuming service.