### PR TITLE
Allow explicitly specifying a response to commands/events

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -10,11 +10,11 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.Headers
 import org.slf4j.LoggerFactory
 import surge.health.{ HealthSignalBusAware, HealthSignalBusTrait }
-import surge.internal.SurgeModel
 import surge.internal.akka.actor.ActorLifecycleManagerActor
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.internal.config.TimeoutConfig
 import surge.internal.kafka.KafkaProducerActorImpl
+import surge.internal.persistence.BusinessLogic
 import surge.kafka.KafkaBytesProducer
 import surge.kafka.streams._
 import surge.metrics.{ MetricInfo, Metrics, Timer }
@@ -29,7 +29,7 @@ object KafkaProducerActor {
       actorSystem: ActorSystem,
       assignedPartition: TopicPartition,
       metrics: Metrics,
-      businessLogic: SurgeModel[_, _, _, _],
+      businessLogic: BusinessLogic,
       kStreams: AggregateStateStoreKafkaStreams[_],
       partitionTracker: KafkaConsumerPartitionAssignmentTracker,
       signalBus: HealthSignalBusTrait,

--- a/modules/command-engine/core/src/main/scala/surge/core/SurgePartitionRouter.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/SurgePartitionRouter.scala
@@ -5,9 +5,9 @@ package surge.core
 import akka.actor._
 import com.typesafe.config.Config
 import surge.health.HealthSignalBusTrait
-import surge.internal.SurgeModel
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.internal.core.SurgePartitionRouterImpl
+import surge.internal.persistence.BusinessLogic
 import surge.kafka.PersistentActorRegionCreator
 import surge.kafka.streams._
 
@@ -20,7 +20,7 @@ object SurgePartitionRouter {
       config: Config,
       system: ActorSystem,
       partitionTracker: KafkaConsumerPartitionAssignmentTracker,
-      businessLogic: SurgeModel[_, _, _, _],
+      businessLogic: BusinessLogic,
       regionCreator: PersistentActorRegionCreator[String],
       signalBus: HealthSignalBusTrait): SurgePartitionRouter = {
     new SurgePartitionRouterImpl(config, system, partitionTracker, businessLogic, regionCreator, signalBus)

--- a/modules/command-engine/core/src/main/scala/surge/core/SurgeProcessingTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/SurgeProcessingTrait.scala
@@ -6,8 +6,8 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import surge.internal.SurgeModel
 
-trait SurgeProcessingTrait[S, M, +R, E] extends Controllable {
-  val businessLogic: SurgeModel[S, M, R, E]
+trait SurgeProcessingTrait[State, Message, +Rejection, Event, Response] extends Controllable {
+  val businessLogic: SurgeModel[State, Message, Rejection, Event, Response]
   def actorSystem: ActorSystem
   def config: Config
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/command/AggregateCommandModelCoreTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/command/AggregateCommandModelCoreTrait.scala
@@ -4,6 +4,6 @@ package surge.core.command
 
 import surge.internal.domain.CommandHandler
 
-trait AggregateCommandModelCoreTrait[S, M, R, E] {
-  def toCore: CommandHandler[S, M, R, E]
+trait AggregateCommandModelCoreTrait[State, Message, Rejection, Event, Response] {
+  def toCore: CommandHandler[State, Message, Rejection, Event, Response]
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/command/SurgeCommandModel.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/command/SurgeCommandModel.scala
@@ -24,9 +24,9 @@ private[surge] case class SurgeCommandKafkaConfig(
 }
 
 private[surge] object SurgeCommandModel {
-  def apply[AggId, Agg, Command, Event](
-      businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event]): SurgeCommandModel[Agg, Command, Nothing, Event] = {
-    new SurgeCommandModel[Agg, Command, Nothing, Event](
+  def apply[AggId, Agg, Command, Event, Response](
+      businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event, Response]): SurgeCommandModel[Agg, Command, Nothing, Event, Response] = {
+    new SurgeCommandModel[Agg, Command, Nothing, Event, Response](
       aggregateName = businessLogic.aggregateName,
       kafka = businessLogic.kafkaConfig,
       model = businessLogic.commandModel.toCore,
@@ -37,9 +37,9 @@ private[surge] object SurgeCommandModel {
       openTelemetry = businessLogic.openTelemetry,
       tracer = businessLogic.tracer)
   }
-  def apply[AggId, Agg, Command, Rej, Event](
-      businessLogic: SurgeRejectableCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event]): SurgeCommandModel[Agg, Command, Rej, Event] = {
-    new SurgeCommandModel[Agg, Command, Rej, Event](
+  def apply[AggId, Agg, Command, Rej, Event, Response](businessLogic: SurgeRejectableCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event, Response])
+      : SurgeCommandModel[Agg, Command, Rej, Event, Response] = {
+    new SurgeCommandModel[Agg, Command, Rej, Event, Response](
       aggregateName = businessLogic.aggregateName,
       kafka = businessLogic.kafkaConfig,
       model = businessLogic.commandModel.toCore,
@@ -52,16 +52,16 @@ private[surge] object SurgeCommandModel {
   }
 
 }
-private[surge] case class SurgeCommandModel[Agg, Command, +Rej, Event](
+private[surge] case class SurgeCommandModel[Agg, Command, +Rej, Event, Response](
     override val aggregateName: String,
     override val kafka: SurgeCommandKafkaConfig,
-    override val model: AggregateProcessingModel[Agg, Command, Rej, Event],
+    override val model: AggregateProcessingModel[Agg, Command, Rej, Event, Response],
     override val aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg],
     override val metrics: Metrics,
     override val openTelemetry: OpenTelemetry,
     override val tracer: Tracer,
     override val aggregateReadFormatting: SurgeAggregateReadFormatting[Agg],
     eventWriteFormatting: SurgeEventWriteFormatting[Event])
-    extends SurgeModel[Agg, Command, Rej, Event] {
+    extends SurgeModel[Agg, Command, Rej, Event, Response] {
   override val eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[Event]] = Some(eventWriteFormatting)
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeCommandBusinessLogic.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeCommandBusinessLogic.scala
@@ -14,7 +14,7 @@ trait SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event] ext
   def eventWriteFormatting: SurgeEventWriteFormatting[Event]
   def aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg]
 
-  def kafkaConfig: SurgeCommandKafkaConfig = new SurgeCommandKafkaConfig(
+  def kafkaConfig: SurgeCommandKafkaConfig = SurgeCommandKafkaConfig(
     stateTopic = stateTopic,
     eventsTopic = eventsTopic,
     streamsApplicationId = streamsApplicationId,
@@ -23,10 +23,11 @@ trait SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event] ext
     publishStateOnly = publishStateOnly)
 }
 
-trait SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event] extends SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Nothing, Event] {
-  def commandModel: AggregateCommandModelCoreTrait[Agg, Command, Nothing, Event]
+trait SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event, Response] extends SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Nothing, Event] {
+  def commandModel: AggregateCommandModelCoreTrait[Agg, Command, Nothing, Event, Response]
 }
 
-trait SurgeRejectableCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event] extends SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event] {
-  def commandModel: AggregateCommandModelCoreTrait[Agg, Command, Rej, Event]
+trait SurgeRejectableCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event, Response]
+    extends SurgeGenericCommandBusinessLogicTrait[AggId, Agg, Command, Rej, Event] {
+  def commandModel: AggregateCommandModelCoreTrait[Agg, Command, Rej, Event, Response]
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeEventBusinessLogicTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeEventBusinessLogicTrait.scala
@@ -4,14 +4,13 @@ package surge.core.commondsl
 
 import surge.core.event.{ AggregateEventModelCoreTrait, SurgeEventKafkaConfig }
 
-trait SurgeEventBusinessLogicTrait[AggId, Agg, Event] extends SurgeGenericBusinessLogicTrait[AggId, Agg, Nothing, Nothing, Event] {
+trait SurgeEventBusinessLogicTrait[AggId, Agg, Event, Response] extends SurgeGenericBusinessLogicTrait[AggId, Agg, Nothing, Nothing, Event] {
 
-  def kafkaConfig: SurgeEventKafkaConfig = new SurgeEventKafkaConfig(
+  def kafkaConfig: SurgeEventKafkaConfig = SurgeEventKafkaConfig(
     stateTopic = stateTopic,
     streamsApplicationId = streamsApplicationId,
     clientId = streamsClientId,
     transactionalIdPrefix = transactionalIdPrefix)
 
-  def eventModel: AggregateEventModelCoreTrait[Agg, Event]
-
+  def eventModel: AggregateEventModelCoreTrait[Agg, Event, Response]
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/event/AggregateEventModelCoreTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/event/AggregateEventModelCoreTrait.scala
@@ -4,6 +4,6 @@ package surge.core.event
 
 import surge.internal.domain.EventHandler
 
-trait AggregateEventModelCoreTrait[S, E] {
-  def toCore: EventHandler[S, E]
+trait AggregateEventModelCoreTrait[State, Event, Response] {
+  def toCore: EventHandler[State, Event, Response]
 }

--- a/modules/command-engine/core/src/main/scala/surge/core/event/SurgeEventServiceModel.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/event/SurgeEventServiceModel.scala
@@ -18,8 +18,9 @@ private[surge] case class SurgeEventKafkaConfig(stateTopic: KafkaTopic, streamsA
 }
 
 object SurgeEventServiceModel {
-  def apply[AggId, Agg, Event](businessLogic: SurgeEventBusinessLogicTrait[AggId, Agg, Event]): SurgeEventServiceModel[Agg, Event] = {
-    new SurgeEventServiceModel[Agg, Event](
+  def apply[AggId, Agg, Event, Response](
+      businessLogic: SurgeEventBusinessLogicTrait[AggId, Agg, Event, Response]): SurgeEventServiceModel[Agg, Event, Response] = {
+    new SurgeEventServiceModel[Agg, Event, Response](
       aggregateName = businessLogic.aggregateName,
       kafka = businessLogic.kafkaConfig,
       model = businessLogic.eventModel.toCore,
@@ -30,15 +31,15 @@ object SurgeEventServiceModel {
       tracer = businessLogic.tracer)
   }
 }
-private[surge] case class SurgeEventServiceModel[Agg, Event](
+private[surge] case class SurgeEventServiceModel[Agg, Event, Response](
     override val aggregateName: String,
     override val kafka: SurgeEventKafkaConfig,
-    override val model: AggregateProcessingModel[Agg, Nothing, Nothing, Event],
+    override val model: AggregateProcessingModel[Agg, Nothing, Nothing, Event, Response],
     override val aggregateReadFormatting: SurgeAggregateReadFormatting[Agg],
     override val aggregateWriteFormatting: SurgeAggregateWriteFormatting[Agg],
     override val metrics: Metrics,
     override val openTelemetry: OpenTelemetry,
     override val tracer: Tracer)
-    extends SurgeModel[Agg, Nothing, Nothing, Event] {
+    extends SurgeModel[Agg, Nothing, Nothing, Event, Response] {
   override def eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[Event]] = None
 }

--- a/modules/command-engine/core/src/main/scala/surge/internal/SurgeModel.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/SurgeModel.scala
@@ -2,7 +2,6 @@
 
 package surge.internal
 
-import io.opentelemetry.api.trace.Tracer
 import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting }
 import surge.internal.domain.AggregateProcessingModel
 import surge.internal.kafka.{ ProducerActorContext, SurgeKafkaConfig }
@@ -12,14 +11,13 @@ import surge.metrics.Metrics
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 
-trait SurgeModel[S, M, +R, E] extends ProducerActorContext {
+trait SurgeModel[State, Message, +Rejection, Event, Response] extends ProducerActorContext {
   override def aggregateName: String
-  def aggregateReadFormatting: SurgeAggregateReadFormatting[S]
-  def aggregateWriteFormatting: SurgeAggregateWriteFormatting[S]
-  def eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[E]]
-  def model: AggregateProcessingModel[S, M, R, E]
+  def aggregateReadFormatting: SurgeAggregateReadFormatting[State]
+  def aggregateWriteFormatting: SurgeAggregateWriteFormatting[State]
+  def eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[Event]]
+  def model: AggregateProcessingModel[State, Message, Rejection, Event, Response]
   override def metrics: Metrics
-  override def tracer: Tracer
   override val kafka: SurgeKafkaConfig
   override val partitioner: KafkaPartitioner[String] = PartitionStringUpToColon
   val executionContext: ExecutionContext = global

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -10,11 +10,10 @@ import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
 import surge.core.{ Ack, Controllable, SurgePartitionRouter }
 import surge.health.HealthSignalBusTrait
-import surge.internal.SurgeModel
 import surge.internal.akka.actor.ActorLifecycleManagerActor
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.internal.config.TimeoutConfig
-import surge.internal.persistence.RoutableMessage
+import surge.internal.persistence.{ BusinessLogic, RoutableMessage }
 import surge.kafka.streams.{ HealthCheck, HealthCheckStatus, HealthyActor, HealthyComponent }
 import surge.kafka.{ KafkaPartitionShardRouterActor, PersistentActorRegionCreator }
 
@@ -26,7 +25,7 @@ private[surge] final class SurgePartitionRouterImpl(
     config: Config,
     system: ActorSystem,
     partitionTracker: KafkaConsumerPartitionAssignmentTracker,
-    businessLogic: SurgeModel[_, _, _, _],
+    businessLogic: BusinessLogic,
     regionCreator: PersistentActorRegionCreator[String],
     signalBus: HealthSignalBusTrait)
     extends SurgePartitionRouter

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeCommandImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeCommandImpl.scala
@@ -7,9 +7,9 @@ import com.typesafe.config.Config
 import surge.core.command.SurgeCommandModel
 import surge.internal.health.HealthSignalStreamProvider
 
-private[surge] abstract class SurgeCommandImpl[Agg, Command, +Rej, Event](
+private[surge] abstract class SurgeCommandImpl[Agg, Command, +Rej, Event, Response](
     actorSystem: ActorSystem,
-    businessLogic: SurgeCommandModel[Agg, Command, Rej, Event],
+    businessLogic: SurgeCommandModel[Agg, Command, Rej, Event, Response],
     signalStreamProvider: HealthSignalStreamProvider,
     config: Config)
-    extends SurgeMessagePipeline[Agg, Command, Rej, Event](actorSystem, businessLogic, signalStreamProvider, config)
+    extends SurgeMessagePipeline[Agg, Command, Rej, Event, Response](actorSystem, businessLogic, signalStreamProvider, config)

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeEventServiceImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeEventServiceImpl.scala
@@ -7,9 +7,9 @@ import com.typesafe.config.Config
 import surge.core.event.SurgeEventServiceModel
 import surge.internal.health.HealthSignalStreamProvider
 
-private[surge] abstract class SurgeEventServiceImpl[Agg, Event](
+private[surge] abstract class SurgeEventServiceImpl[Agg, Event, Response](
     actorSystem: ActorSystem,
-    businessLogic: SurgeEventServiceModel[Agg, Event],
+    businessLogic: SurgeEventServiceModel[Agg, Event, Response],
     signalStreamProvider: HealthSignalStreamProvider,
     config: Config)
-    extends SurgeMessagePipeline[Agg, Nothing, Nothing, Event](actorSystem, businessLogic, signalStreamProvider, config)
+    extends SurgeMessagePipeline[Agg, Nothing, Nothing, Event, Response](actorSystem, businessLogic, signalStreamProvider, config)

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
@@ -26,12 +26,12 @@ object SurgeMessagePipeline {
 /**
  * Surge message processing pipeline
  */
-private[surge] abstract class SurgeMessagePipeline[S, M, +R, E](
+private[surge] abstract class SurgeMessagePipeline[State, Message, +Rejection, Event, Response](
     actorSystem: ActorSystem,
-    override val businessLogic: SurgeModel[S, M, R, E],
+    override val businessLogic: SurgeModel[State, Message, Rejection, Event, Response],
     val signalStreamProvider: HealthSignalStreamProvider,
     override val config: Config)
-    extends SurgeProcessingTrait[S, M, R, E]
+    extends SurgeProcessingTrait[State, Message, Rejection, Event, Response]
     with HealthyComponent
     with HealthSignalBusAware
     with ActorSystemHostAwareness {
@@ -59,8 +59,8 @@ private[surge] abstract class SurgeMessagePipeline[S, M, +R, E](
     signalBus = signalBus,
     config = config)
 
-  protected val cqrsRegionCreator: PersistentActorRegionCreator[M] =
-    new PersistentActorRegionCreator[M](actorSystem, businessLogic, kafkaStreamsImpl, partitionTracker, businessLogic.metrics, signalBus, config = config)
+  protected val cqrsRegionCreator: PersistentActorRegionCreator[Message] =
+    new PersistentActorRegionCreator[Message](actorSystem, businessLogic, kafkaStreamsImpl, partitionTracker, businessLogic.metrics, signalBus, config = config)
 
   protected val actorRouter: SurgePartitionRouter = SurgePartitionRouter(config, actorSystem, partitionTracker, businessLogic, cqrsRegionCreator, signalBus)
 

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/Context.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/Context.scala
@@ -5,7 +5,7 @@ package surge.internal.persistence
 import scala.concurrent.ExecutionContext
 
 private[surge] object Context {
-  def apply(executionContext: ExecutionContext, actor: PersistentActor[_, _, _, _]): Context = new Context(executionContext, actor)
+  def apply(executionContext: ExecutionContext, actor: PersistentActor[_, _, _, _, _]): Context = new Context(executionContext, actor)
 }
 
-private[surge] class Context private (val executionContext: ExecutionContext, val actor: PersistentActor[_, _, _, _])
+private[surge] class Context private (val executionContext: ExecutionContext, val actor: PersistentActor[_, _, _, _, _])

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/package.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/package.scala
@@ -3,5 +3,5 @@
 package surge.internal
 
 package object persistence {
-  type BusinessLogic = SurgeModel[_, _, _, _]
+  type BusinessLogic = SurgeModel[_, _, _, _, _]
 }

--- a/modules/command-engine/core/src/test/scala/surge/core/AggregateRefTraitSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/core/AggregateRefTraitSpec.scala
@@ -14,7 +14,6 @@ import surge.internal.persistence.{ AggregateRefTrait, PersistentActor }
 import surge.internal.tracing.{ NoopTracerFactory, ProbeWithTraceSupport }
 
 import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
 
 class AggregateRefTraitSpec
     extends TestKit(ActorSystem("AggregateRefTraitSpec"))
@@ -30,7 +29,7 @@ class AggregateRefTraitSpec
   case class Person(name: String, favoriteColor: String)
 
   private val noopTracer = NoopTracerFactory.create()
-  case class TestAggregateRef(aggregateId: String, regionTestProbe: TestProbe) extends AggregateRefTrait[String, Person, String, String] {
+  case class TestAggregateRef(aggregateId: String, regionTestProbe: TestProbe) extends AggregateRefTrait[String, Person, String, String, Person] {
     override val region: ActorRef = system.actorOf(Props(new ProbeWithTraceSupport(regionTestProbe, noopTracer)))
     override val tracer: Tracer = noopTracer
 

--- a/modules/command-engine/core/src/test/scala/surge/core/TestBoundedContext.scala
+++ b/modules/command-engine/core/src/test/scala/surge/core/TestBoundedContext.scala
@@ -83,7 +83,7 @@ trait TestBoundedContext {
   implicit val countIncrementedFormat: Format[CountIncremented] = Json.format
   implicit val countDecrementedFormat: Format[CountDecremented] = Json.format
 
-  trait BusinessLogicTrait extends CommandHandler[State, BaseTestCommand, Nothing, BaseTestEvent] {
+  trait BusinessLogicTrait extends CommandHandler[State, BaseTestCommand, Nothing, BaseTestEvent, State] {
 
     override def apply(ctx: Context, agg: Option[State], evt: BaseTestEvent): Option[State] = handleEvent(agg, evt)
     def handleEvent(agg: Option[State], evt: BaseTestEvent): Option[State] = {
@@ -120,6 +120,8 @@ trait TestBoundedContext {
           throw new RuntimeException("Received unexpected message in command handler! This should not happen and indicates a bad test")
       }
     }
+
+    override def extractResponse(state: Option[State]): Option[State] = state
   }
 
   object BusinessLogic extends BusinessLogicTrait
@@ -143,7 +145,7 @@ trait TestBoundedContext {
     SerializedMessage(key, body, Map.empty)
   }
 
-  val businessLogic: SurgeCommandModel[State, BaseTestCommand, Nothing, BaseTestEvent] =
+  val businessLogic: SurgeCommandModel[State, BaseTestCommand, Nothing, BaseTestEvent, State] =
     command.SurgeCommandModel(
       aggregateName = "CountAggregate",
       kafka = kafkaConfig,

--- a/modules/command-engine/core/src/test/scala/surge/internal/domain/SurgeMessagePipelineSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/domain/SurgeMessagePipelineSpec.scala
@@ -51,7 +51,7 @@ class SurgeMessagePipelineSpec
   case class TestContext(
       probe: TestProbe,
       signalStreamProvider: SlidingHealthSignalStreamProvider,
-      pipeline: SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent])
+      pipeline: SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent, State])
 
   def withTestContext[T](testFun: TestContext => T): T = {
     val probe = TestProbe()
@@ -289,8 +289,9 @@ class SurgeMessagePipelineSpec
     }
   }
 
-  private def createPipeline(signalStreamProvider: SlidingHealthSignalStreamProvider): SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent] = {
-    new SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent](system, businessLogic, signalStreamProvider, defaultConfig) {
+  private def createPipeline(
+      signalStreamProvider: SlidingHealthSignalStreamProvider): SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent, State] = {
+    new SurgeMessagePipeline[State, BaseTestCommand, Nothing, BaseTestEvent, State](system, businessLogic, signalStreamProvider, defaultConfig) {
 
       override def actorSystem: ActorSystem = system
 

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/CommandModels.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/CommandModels.scala
@@ -16,29 +16,33 @@ import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-trait AggregateCommandModel[Agg, Cmd, Evt] extends AggregateCommandModelCoreTrait[Agg, Cmd, Nothing, Evt] {
+trait AggregateCommandModel[Agg, Cmd, Evt, Response] extends AggregateCommandModelCoreTrait[Agg, Cmd, Nothing, Evt, Response] {
   def processCommand(aggregate: Optional[Agg], command: Cmd): JList[Evt]
   def handleEvent(aggregate: Optional[Agg], event: Evt): Optional[Agg]
+  def extractResponse(aggregate: Optional[Agg]): Optional[Response]
 
-  final def toCore: CommandHandler[Agg, Cmd, Nothing, Evt] =
-    new CommandHandler[Agg, Cmd, Nothing, Evt] {
+  final def toCore: CommandHandler[Agg, Cmd, Nothing, Evt, Response] =
+    new CommandHandler[Agg, Cmd, Nothing, Evt, Response] {
       override def processCommand(ctx: persistence.Context, state: Option[Agg], cmd: Cmd): Future[CommandResult] =
         Future.fromTry(Try(Right(AggregateCommandModel.this.processCommand(state.asJava, cmd).asScala.toSeq)))
       override def apply(ctx: persistence.Context, state: Option[Agg], event: Evt): Option[Agg] = handleEvent(state.asJava, event).asScala
+      override def extractResponse(state: Option[Agg]): Option[Response] = AggregateCommandModel.this.extractResponse(state.asJava).asScala
     }
 }
 
-trait ContextAwareAggregateCommandModel[Agg, Cmd, Evt] extends AggregateCommandModelCoreTrait[Agg, Cmd, Nothing, Evt] {
+trait ContextAwareAggregateCommandModel[Agg, Cmd, Evt, Response] extends AggregateCommandModelCoreTrait[Agg, Cmd, Nothing, Evt, Response] {
   def processCommand(ctx: common.Context, aggregate: Optional[Agg], command: Cmd): CompletableFuture[Seq[Evt]]
   def handleEvent(ctx: common.Context, aggregate: Optional[Agg], event: Evt): Optional[Agg]
+  def extractResponse(agg: Optional[Agg]): Optional[Response]
 
-  final def toCore: CommandHandler[Agg, Cmd, Nothing, Evt] =
-    new CommandHandler[Agg, Cmd, Nothing, Evt] {
+  final def toCore: CommandHandler[Agg, Cmd, Nothing, Evt, Response] =
+    new CommandHandler[Agg, Cmd, Nothing, Evt, Response] {
       override def processCommand(ctx: persistence.Context, state: Option[Agg], cmd: Cmd): Future[CommandResult] =
         FutureConverters
           .toScala(ContextAwareAggregateCommandModel.this.processCommand(Context(ctx), state.asJava, cmd))
           .map(v => Right(v))(ctx.executionContext)
       override def apply(ctx: persistence.Context, state: Option[Agg], event: Evt): Option[Agg] = handleEvent(Context(ctx), state.asJava, event).asScala
+      override def extractResponse(state: Option[Agg]): Option[Response] = ContextAwareAggregateCommandModel.this.extractResponse(state.asJava).asScala
     }
 }
 
@@ -53,7 +57,7 @@ trait ContextAwareAggregateCommandModel[Agg, Cmd, Evt] extends AggregateCommandM
  * @tparam Evt
  *   event type
  */
-trait RejectableAggregateCommandModel[Agg, Cmd, Rej, Evt] extends AggregateCommandModelCoreTrait[Agg, Cmd, Rej, Evt] {
+trait RejectableAggregateCommandModel[Agg, Cmd, Rej, Evt, Response] extends AggregateCommandModelCoreTrait[Agg, Cmd, Rej, Evt, Response] {
 
   /**
    * Process a command
@@ -81,10 +85,13 @@ trait RejectableAggregateCommandModel[Agg, Cmd, Rej, Evt] extends AggregateComma
    */
   def handleEvent(ctx: Context, aggregate: Optional[Agg], event: Evt): Optional[Agg]
 
-  final def toCore: CommandHandler[Agg, Cmd, Rej, Evt] =
-    new CommandHandler[Agg, Cmd, Rej, Evt] {
+  def extractResponse(agg: Optional[Agg]): Optional[Response]
+
+  final def toCore: CommandHandler[Agg, Cmd, Rej, Evt, Response] =
+    new CommandHandler[Agg, Cmd, Rej, Evt, Response] {
       override def processCommand(ctx: persistence.Context, state: Option[Agg], cmd: Cmd): Future[CommandResult] =
         FutureConverters.toScala(RejectableAggregateCommandModel.this.processCommand(Context(ctx), state.asJava, cmd))
       override def apply(ctx: persistence.Context, state: Option[Agg], event: Evt): Option[Agg] = handleEvent(Context(ctx), state.asJava, event).asScala
+      override def extractResponse(state: Option[Agg]): Option[Response] = RejectableAggregateCommandModel.this.extractResponse(state.asJava).asScala
     }
 }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/ConsumerRebalanceListener.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/ConsumerRebalanceListener.scala
@@ -5,6 +5,6 @@ package surge.javadsl.command
 import org.apache.kafka.common.TopicPartition
 import surge.kafka.HostPort
 
-trait ConsumerRebalanceListener[AggId, Agg, Command, Rej, Evt] {
-  def onRebalance(engine: SurgeCommand[AggId, Agg, Command, Rej, Evt], assignments: java.util.Map[HostPort, java.util.List[TopicPartition]]): Unit
+trait ConsumerRebalanceListener[AggId, Agg, Command, Rej, Evt, Response] {
+  def onRebalance(engine: SurgeCommand[AggId, Agg, Command, Rej, Evt, Response], assignments: java.util.Map[HostPort, java.util.List[TopicPartition]]): Unit
 }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommandBuilder.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommandBuilder.scala
@@ -4,17 +4,17 @@ package surge.javadsl.command
 
 import surge.core.commondsl.SurgeCommandBusinessLogicTrait
 
-class Buildable[AggId, Agg, Command, Evt](businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Evt]) {
-  def build(): SurgeCommand[AggId, Agg, Command, Nothing, Evt] = {
+class Buildable[AggId, Agg, Command, Evt, Response](businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Evt, Response]) {
+  def build(): SurgeCommand[AggId, Agg, Command, Nothing, Evt, Response] = {
     SurgeCommand.create(businessLogic)
   }
 }
 
 class SurgeCommandBuilder {
 
-  def withBusinessLogic[AggId, Agg, Command, Evt](
-      businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Evt]): Buildable[AggId, Agg, Command, Evt] = {
-    new Buildable[AggId, Agg, Command, Evt](businessLogic)
+  def withBusinessLogic[AggId, Agg, Command, Evt, Response](
+      businessLogic: SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Evt, Response]): Buildable[AggId, Agg, Command, Evt, Response] = {
+    new Buildable[AggId, Agg, Command, Evt, Response](businessLogic)
   }
 
 }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommandBusinessLogic.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommandBusinessLogic.scala
@@ -5,8 +5,8 @@ package surge.javadsl.command
 import surge.core.commondsl.SurgeCommandBusinessLogicTrait
 import surge.javadsl.common.DefaultAggregateValidator
 
-abstract class SurgeCommandBusinessLogic[AggId, Agg, Command, Event]
-    extends SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event]
+abstract class SurgeCommandBusinessLogic[AggId, Agg, Command, Event, Response]
+    extends SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event, Response]
     with DefaultAggregateValidator {
 
   @deprecated("Will be removed from here once an alternative model to CQRS processing is available.", "0.5.2")

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/common/AggregateRefBaseTrait.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/common/AggregateRefBaseTrait.scala
@@ -12,7 +12,7 @@ import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext
 
-trait AggregateRefBaseTrait[AggId, Agg, Cmd, Event] extends AggregateRefTrait[AggId, Agg, Cmd, Event] {
+trait AggregateRefBaseTrait[AggId, Agg, Cmd, Event, Response] extends AggregateRefTrait[AggId, Agg, Cmd, Event, Response] {
 
   val aggregateId: AggId
   protected val region: ActorRef
@@ -24,10 +24,10 @@ trait AggregateRefBaseTrait[AggId, Agg, Cmd, Event] extends AggregateRefTrait[Ag
     FutureConverters.toJava(queryState.map(_.asJava))
   }
 
-  def applyEvent(event: Event): CompletionStage[ApplyEventResult[Agg]] = {
+  def applyEvent(event: Event): CompletionStage[ApplyEventResult[Response]] = {
     val envelope = PersistentActor.ApplyEvent[Event](aggregateId.toString, event)
-    val result = applyEventsWithRetries(envelope).map(aggOpt => ApplyEventSuccess[Agg](aggOpt.asJava)).recover { case e =>
-      ApplyEventFailure[Agg](e)
+    val result = applyEventsWithRetries(envelope).map(aggOpt => ApplyEventSuccess[Response](aggOpt.asJava)).recover { case e =>
+      ApplyEventFailure[Response](e)
     }
     FutureConverters.toJava(result)
   }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/common/AggregateRefResults.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/common/AggregateRefResults.scala
@@ -4,10 +4,10 @@ package surge.javadsl.common
 
 import java.util.Optional
 
-sealed trait CommandResult[Agg]
-case class CommandSuccess[Agg](aggregateState: Optional[Agg]) extends CommandResult[Agg]
-case class CommandFailure[Agg](reason: Throwable) extends CommandResult[Agg]
+sealed trait CommandResult[Reply]
+case class CommandSuccess[Reply](reply: Optional[Reply]) extends CommandResult[Reply]
+case class CommandFailure[Reply](reason: Throwable) extends CommandResult[Reply]
 
-sealed trait ApplyEventResult[Agg]
-case class ApplyEventSuccess[Agg](aggregateState: Optional[Agg]) extends ApplyEventResult[Agg]
-case class ApplyEventFailure[Agg](reason: Throwable) extends ApplyEventResult[Agg]
+sealed trait ApplyEventResult[Reply]
+case class ApplyEventSuccess[Reply](reply: Optional[Reply]) extends ApplyEventResult[Reply]
+case class ApplyEventFailure[Reply](reason: Throwable) extends ApplyEventResult[Reply]

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/AggregateEventModel.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/AggregateEventModel.scala
@@ -3,7 +3,6 @@
 package surge.javadsl.event
 
 import surge.core.event.AggregateEventModelCoreTrait
-import surge.internal
 import surge.internal.domain.EventHandler
 import surge.internal.persistence
 import surge.javadsl.common.Context
@@ -11,9 +10,13 @@ import surge.javadsl.common.Context
 import java.util.Optional
 import scala.compat.java8.OptionConverters._
 
-trait AggregateEventModel[Agg, Evt] extends AggregateEventModelCoreTrait[Agg, Evt] {
+trait AggregateEventModel[Agg, Evt, Response] extends AggregateEventModelCoreTrait[Agg, Evt, Response] {
   def handleEvent(ctx: Context, state: Optional[Agg], event: Evt): Optional[Agg]
+  def extractResponse(state: Optional[Agg]): Optional[Response]
 
-  override def toCore: EventHandler[Agg, Evt] = (ctx: persistence.Context, state: Option[Agg], event: Evt) =>
-    handleEvent(Context(ctx), state.asJava, event).asScala
+  override def toCore: EventHandler[Agg, Evt, Response] = new EventHandler[Agg, Evt, Response] {
+    override def handleEvent(ctx: persistence.Context, state: Option[Agg], event: Evt): Option[Agg] =
+      AggregateEventModel.this.handleEvent(Context(ctx), state.asJava, event).asScala
+    override def extractResponse(state: Option[Agg]): Option[Response] = AggregateEventModel.this.extractResponse(state.asJava).asScala
+  }
 }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/AggregateRef.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/AggregateRef.scala
@@ -9,11 +9,11 @@ import surge.javadsl.common._
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
-trait AggregateRef[Agg, Event] {
+trait AggregateRef[Agg, Event, Response] {
   def getState: CompletionStage[Optional[Agg]]
-  def applyEvent(event: Event): CompletionStage[ApplyEventResult[Agg]]
+  def applyEvent(event: Event): CompletionStage[ApplyEventResult[Response]]
 }
 
-class AggregateRefImpl[AggId, Agg, Event](val aggregateId: AggId, protected val region: ActorRef, protected val tracer: Tracer)
-    extends AggregateRef[Agg, Event]
-    with AggregateRefBaseTrait[AggId, Agg, Nothing, Event]
+class AggregateRefImpl[AggId, Agg, Event, Response](val aggregateId: AggId, protected val region: ActorRef, protected val tracer: Tracer)
+    extends AggregateRef[Agg, Event, Response]
+    with AggregateRefBaseTrait[AggId, Agg, Nothing, Event, Response]

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/ConsumerRebalanceListener.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/ConsumerRebalanceListener.scala
@@ -5,6 +5,6 @@ package surge.javadsl.event
 import org.apache.kafka.common.TopicPartition
 import surge.kafka.HostPort
 
-trait ConsumerRebalanceListener[AggId, Agg, Evt] {
-  def onRebalance(engine: SurgeEvent[AggId, Agg, Evt], assignments: java.util.Map[HostPort, java.util.List[TopicPartition]]): Unit
+trait ConsumerRebalanceListener[AggId, Agg, Evt, Response] {
+  def onRebalance(engine: SurgeEvent[AggId, Agg, Evt, Response], assignments: java.util.Map[HostPort, java.util.List[TopicPartition]]): Unit
 }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/SurgeEventBusinessLogic.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/SurgeEventBusinessLogic.scala
@@ -5,6 +5,8 @@ package surge.javadsl.event
 import surge.core.commondsl.SurgeEventBusinessLogicTrait
 import surge.javadsl.common.DefaultAggregateValidator
 
-abstract class SurgeEventBusinessLogic[AggId, Agg, Event] extends SurgeEventBusinessLogicTrait[AggId, Agg, Event] with DefaultAggregateValidator {
+abstract class SurgeEventBusinessLogic[AggId, Agg, Event, Response]
+    extends SurgeEventBusinessLogicTrait[AggId, Agg, Event, Response]
+    with DefaultAggregateValidator {
   override final def publishStateOnly: Boolean = true
 }

--- a/modules/command-engine/javadsl/src/test/scala/surge/javadsl/command/CommandModelsSpec.scala
+++ b/modules/command-engine/javadsl/src/test/scala/surge/javadsl/command/CommandModelsSpec.scala
@@ -16,9 +16,10 @@ class CommandModelsSpec extends AsyncWordSpec with Matchers with MockitoSugar wi
   "AggregateCommandModel" should {
     "Return a failed future when the business logic throws an exception processing commands" in {
       val expectedException = new RuntimeException("This is expected") with NoStackTrace
-      val exceptionThrowingModel = new AggregateCommandModel[String, String, String] {
+      val exceptionThrowingModel = new AggregateCommandModel[String, String, String, String] {
         override def processCommand(aggregate: Optional[String], command: String): util.List[String] = throw expectedException
         override def handleEvent(aggregate: Optional[String], event: String): Optional[String] = Optional.empty()
+        override def extractResponse(aggregate: Optional[String]): Optional[String] = aggregate
       }
       recoverToSucceededIf[RuntimeException] {
         exceptionThrowingModel.toCore.processCommand(mock[Context], None, "Test")

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/ConsumerRebalanceListener.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/ConsumerRebalanceListener.scala
@@ -5,6 +5,6 @@ package surge.scaladsl.command
 import org.apache.kafka.common.TopicPartition
 import surge.kafka.HostPort
 
-trait ConsumerRebalanceListener[AggId, Agg, Command, Rej, Evt] {
-  def onRebalance(engine: SurgeCommand[AggId, Agg, Command, Rej, Evt], assignments: Map[HostPort, List[TopicPartition]]): Unit
+trait ConsumerRebalanceListener[AggId, Agg, Command, Rej, Evt, Response] {
+  def onRebalance(engine: SurgeCommand[AggId, Agg, Command, Rej, Evt, Response], assignments: Map[HostPort, List[TopicPartition]]): Unit
 }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/SurgeCommandBusinessLogic.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/command/SurgeCommandBusinessLogic.scala
@@ -5,8 +5,8 @@ package surge.scaladsl.command
 import surge.core.commondsl.SurgeCommandBusinessLogicTrait
 import surge.scaladsl.common.DefaultAggregateValidator
 
-abstract class SurgeCommandBusinessLogic[AggId, Agg, Command, Event]
-    extends SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event]
+abstract class SurgeCommandBusinessLogic[AggId, Agg, Command, Event, Response]
+    extends SurgeCommandBusinessLogicTrait[AggId, Agg, Command, Event, Response]
     with DefaultAggregateValidator {
 
   @deprecated("Will be removed from here once an alternative model to CQRS processing is available.", "0.5.2")

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/common/AggregateRefBaseTrait.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/common/AggregateRefBaseTrait.scala
@@ -8,7 +8,7 @@ import surge.internal.persistence.{ AggregateRefTrait, PersistentActor }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait AggregateRefBaseTrait[AggId, Agg, Cmd, Event] extends AggregateRefTrait[AggId, Agg, Cmd, Event] {
+trait AggregateRefBaseTrait[AggId, Agg, Cmd, Event, Response] extends AggregateRefTrait[AggId, Agg, Cmd, Event, Response] {
 
   val aggregateId: AggId
   protected val region: ActorRef
@@ -20,10 +20,10 @@ trait AggregateRefBaseTrait[AggId, Agg, Cmd, Event] extends AggregateRefTrait[Ag
     queryState
   }
 
-  def applyEvent(event: Event): Future[ApplyEventResult[Agg]] = {
+  def applyEvent(event: Event): Future[ApplyEventResult[Response]] = {
     val envelope = PersistentActor.ApplyEvent[Event](aggregateId.toString, event)
-    applyEventsWithRetries(envelope).map(aggOpt => ApplyEventSuccess[Agg](aggOpt)).recover { case e =>
-      ApplyEventFailure[Agg](e)
+    applyEventsWithRetries(envelope).map(aggOpt => ApplyEventSuccess[Response](aggOpt)).recover { case e =>
+      ApplyEventFailure[Response](e)
     }
   }
 }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/common/AggregateRefResult.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/common/AggregateRefResult.scala
@@ -2,10 +2,10 @@
 
 package surge.scaladsl.common
 
-sealed trait CommandResult[Agg]
-case class CommandSuccess[Agg](aggregateState: Option[Agg]) extends CommandResult[Agg]
-case class CommandFailure[Agg](reason: Throwable) extends CommandResult[Agg]
+sealed trait CommandResult[Reply]
+case class CommandSuccess[Reply](reply: Option[Reply]) extends CommandResult[Reply]
+case class CommandFailure[Reply](reason: Throwable) extends CommandResult[Reply]
 
-sealed trait ApplyEventResult[Agg]
-case class ApplyEventSuccess[Agg](aggregateState: Option[Agg]) extends ApplyEventResult[Agg]
-case class ApplyEventFailure[Agg](reason: Throwable) extends ApplyEventResult[Agg]
+sealed trait ApplyEventResult[Reply]
+case class ApplyEventSuccess[Reply](reply: Option[Reply]) extends ApplyEventResult[Reply]
+case class ApplyEventFailure[Reply](reason: Throwable) extends ApplyEventResult[Reply]

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/AggregateEventModel.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/AggregateEventModel.scala
@@ -3,13 +3,17 @@
 package surge.scaladsl.event
 
 import surge.core.event.AggregateEventModelCoreTrait
-import surge.internal
 import surge.internal.domain.EventHandler
 import surge.internal.persistence
 import surge.scaladsl.common.Context
 
-trait AggregateEventModel[Agg, Evt] extends AggregateEventModelCoreTrait[Agg, Evt] {
+trait AggregateEventModel[Agg, Evt, Response] extends AggregateEventModelCoreTrait[Agg, Evt, Response] {
   def handleEvent(ctx: Context, state: Option[Agg], event: Evt): Option[Agg]
+  def extractResponse(agg: Option[Agg]): Option[Response]
 
-  override def toCore: EventHandler[Agg, Evt] = (ctx: persistence.Context, state: Option[Agg], event: Evt) => handleEvent(Context(ctx), state, event)
+  override def toCore: EventHandler[Agg, Evt, Response] = new EventHandler[Agg, Evt, Response] {
+    override def handleEvent(ctx: persistence.Context, state: Option[Agg], event: Evt): Option[Agg] =
+      AggregateEventModel.this.handleEvent(Context(ctx), state, event)
+    override def extractResponse(state: Option[Agg]): Option[Response] = AggregateEventModel.this.extractResponse(state)
+  }
 }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/AggregateRef.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/AggregateRef.scala
@@ -8,11 +8,11 @@ import surge.scaladsl.common._
 
 import scala.concurrent.Future
 
-trait AggregateRef[Agg, Event] {
+trait AggregateRef[Agg, Event, Response] {
   def getState: Future[Option[Agg]]
-  def applyEvent(event: Event): Future[ApplyEventResult[Agg]]
+  def applyEvent(event: Event): Future[ApplyEventResult[Response]]
 }
 
-class AggregateRefImpl[AggId, Agg, Event](val aggregateId: AggId, protected val region: ActorRef, protected val tracer: Tracer)
-    extends AggregateRef[Agg, Event]
-    with AggregateRefBaseTrait[AggId, Agg, Nothing, Event]
+class AggregateRefImpl[AggId, Agg, Event, Response](val aggregateId: AggId, protected val region: ActorRef, protected val tracer: Tracer)
+    extends AggregateRef[Agg, Event, Response]
+    with AggregateRefBaseTrait[AggId, Agg, Nothing, Event, Response]

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/ConsumerRebalanceListener.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/ConsumerRebalanceListener.scala
@@ -5,6 +5,6 @@ package surge.scaladsl.event
 import org.apache.kafka.common.TopicPartition
 import surge.kafka.HostPort
 
-trait ConsumerRebalanceListener[AggId, Agg, Evt] {
-  def onRebalance(engine: SurgeEvent[AggId, Agg, Evt], assignments: Map[HostPort, List[TopicPartition]]): Unit
+trait ConsumerRebalanceListener[AggId, Agg, Evt, Response] {
+  def onRebalance(engine: SurgeEvent[AggId, Agg, Evt, Response], assignments: Map[HostPort, List[TopicPartition]]): Unit
 }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/SurgeEventBusinessLogic.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/event/SurgeEventBusinessLogic.scala
@@ -5,6 +5,8 @@ package surge.scaladsl.event
 import surge.core.commondsl.SurgeEventBusinessLogicTrait
 import surge.scaladsl.common.DefaultAggregateValidator
 
-abstract class SurgeEventBusinessLogic[AggId, Agg, Event] extends SurgeEventBusinessLogicTrait[AggId, Agg, Event] with DefaultAggregateValidator {
+abstract class SurgeEventBusinessLogic[AggId, Agg, Event, Response]
+    extends SurgeEventBusinessLogicTrait[AggId, Agg, Event, Response]
+    with DefaultAggregateValidator {
   override final def publishStateOnly: Boolean = true
 }

--- a/modules/surge-docs/src/test/java/javadocs/commandapp/BankAccountCommandModel.java
+++ b/modules/surge-docs/src/test/java/javadocs/commandapp/BankAccountCommandModel.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Optional;
 
 // #command_model_class
-public class BankAccountCommandModel implements AggregateCommandModel<BankAccount, BankAccountCommand, BankAccountEvent> {
+public class BankAccountCommandModel implements AggregateCommandModel<BankAccount, BankAccountCommand, BankAccountEvent, BankAccount> {
 
     @Override
     public List<BankAccountEvent> processCommand(Optional<BankAccount> aggregate, BankAccountCommand command) {
@@ -79,6 +79,11 @@ public class BankAccountCommandModel implements AggregateCommandModel<BankAccoun
                     , item.securityCode(), bankAccountUpdated.amount()));
         }
         throw new RuntimeException("Unhandled event");
+    }
+
+    @Override
+    public Optional<BankAccount> extractResponse(Optional<BankAccount> aggregate) {
+        return aggregate;
     }
 
 }

--- a/modules/surge-docs/src/test/java/javadocs/commandapp/BankAccountSurgeModel.java
+++ b/modules/surge-docs/src/test/java/javadocs/commandapp/BankAccountSurgeModel.java
@@ -18,9 +18,9 @@ import java.util.UUID;
 
 // #surge_model_class
 public class BankAccountSurgeModel extends SurgeCommandBusinessLogic<UUID, BankAccount, BankAccountCommand,
-        BankAccountEvent> {
+        BankAccountEvent, BankAccount> {
     @Override
-    public AggregateCommandModel<BankAccount, BankAccountCommand, BankAccountEvent> commandModel() {
+    public AggregateCommandModel<BankAccount, BankAccountCommand, BankAccountEvent, BankAccount> commandModel() {
         return new BankAccountCommandModel();
     }
 


### PR DESCRIPTION
Allows explicitly specifying a response to reply with to a message based on the aggregate state after handling the command. For full context, the same state can be returned (current behavior today) but this should allow filtering of extra/unnecessary fields at the aggregate level so the full state doesn't need be be sent remotely in the reply if the full state happens to be much larger than what an app cares about for replying to the command.