### PR TITLE
Prevent scheduled messages from hitting dead letters on ProducerActor shutdown

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -51,7 +51,7 @@ object KafkaProducerActor {
         kafkaProducerOverride = kafkaProducerOverride)).withDispatcher(dispatcherName)
 
     new KafkaProducerActor(
-      actorSystem.actorOf(Props(new ActorLifecycleManagerActor(kafkaProducerProps))),
+      actorSystem.actorOf(Props(new ActorLifecycleManagerActor(kafkaProducerProps, s"producer-actor-${assignedPartition.toString}"))),
       metrics,
       businessLogic.aggregateName,
       assignedPartition,

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -43,7 +43,9 @@ private[surge] final class SurgePartitionRouterImpl(
     regionCreator,
     RoutableMessage.extractEntityId)(businessLogic.tracer)
 
-  private val lifecycleManager = system.actorOf(Props(new ActorLifecycleManagerActor(shardRouterProps, Some(s"${businessLogic.aggregateName}RouterActor"))))
+  private val routerActorName = s"${businessLogic.aggregateName}RouterActor"
+  private val lifecycleManager =
+    system.actorOf(Props(new ActorLifecycleManagerActor(shardRouterProps, componentName = routerActorName, managedActorName = Some(routerActorName))))
   override val actorRegion: ActorRef = lifecycleManager
 
   override def start(): Future[Ack] = {

--- a/modules/common/src/main/scala/surge/kafka/KafkaPartitionShardRouterActor.scala
+++ b/modules/common/src/main/scala/surge/kafka/KafkaPartitionShardRouterActor.scala
@@ -19,7 +19,6 @@ import surge.kafka.streams.{ HealthCheck, HealthCheckStatus, HealthyActor }
 import java.time.Instant
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.Try
 
 object KafkaPartitionShardRouterActor {
   def props[Agg, Command, Event](
@@ -312,7 +311,7 @@ class KafkaPartitionShardRouterActor(
         case err: Throwable =>
           log.error(s"Failed to get partition region health check ${partitionRegion.regionManager.pathString}", err)
           Future.successful(
-            HealthCheck(name = partitionRegion.regionManager.pathString, id = partitionRegion.regionManager.pathString, status = HealthCheckStatus.DOWN))
+            HealthCheck(name = "shard", id = new TopicPartition(trackedTopic.name, partitionRegion.partitionNumber).toString, status = HealthCheckStatus.DOWN))
       }
     }.toSeq
   }

--- a/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
@@ -138,7 +138,13 @@ class AggregateStateStoreKafkaStreams[Agg >: Null](
         .withMaxNrOfRetries(BackoffConfig.StateStoreKafkaStreamActor.maxRetries))
 
     val underlyingCreatedActor =
-      system.actorOf(Props(new ActorLifecycleManagerActor(underlyingActorProps, initMessage = Some(() => Start), finalizeMessage = Some(() => Stop))))
+      system.actorOf(
+        Props(
+          new ActorLifecycleManagerActor(
+            underlyingActorProps,
+            componentName = s"state-store-kafka-streams-$aggregateName",
+            initMessage = Some(() => Start),
+            finalizeMessage = Some(() => Stop))))
 
     system.actorOf(BackoffChildActorTerminationWatcher.props(underlyingCreatedActor, () => onMaxRetries()))
 


### PR DESCRIPTION
Additional things:
- Adds a `componentName` to the `ActorLifecycleManagerActor` for clearer logs
- Avoids some of the stashing in the producer actor by handling KTable progress updates in different states
- Make sure the names/ids for a couple health check components are the same in both success/failure cases.