### PR TITLE
Temp fix: don't stop producer actor or partition router in stop() methods

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -153,7 +153,8 @@ class KafkaProducerActor(
   override def stop(): Future[Ack] = {
     implicit val askTimeout: Timeout = Timeout(TimeoutConfig.LifecycleManagerActor.askTimeout)
 
-    publisherActor.ask(ActorLifecycleManagerActor.Stop).mapTo[Ack]
+    //publisherActor.ask(ActorLifecycleManagerActor.Stop).mapTo[Ack]
+    Future.successful(Ack())
   }
 
   override def shutdown(): Future[Ack] = stop()

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -57,7 +57,8 @@ private[surge] final class SurgePartitionRouterImpl(
   override def stop(): Future[Ack] = {
     implicit val askTimeout: Timeout = Timeout(TimeoutConfig.PartitionRouter.askTimeout)
 
-    actorRegion.ask(ActorLifecycleManagerActor.Stop).mapTo[Ack]
+    //actorRegion.ask(ActorLifecycleManagerActor.Stop).mapTo[Ack]
+    Future.successful(Ack())
   }
 
   override def shutdown(): Future[Ack] = stop()


### PR DESCRIPTION
In a couple of places it seems the actor lifecycle manager is told to stop a couple of components when it should not. This leads to unexpected behavior in the engine as components expected to be running are not.