### PR TITLE
Have ProducerActor handle exceptions thrown by consumer lag checker

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
@@ -229,11 +229,15 @@ class KafkaProducerActorImpl(
   }
 
   private def checkKTableProgress(): Unit = {
-    lagChecker.getConsumerGroupLag(assignedPartition) match {
-      case Some(lag) =>
+    Future {
+      lagChecker.getConsumerGroupLag(assignedPartition)
+    }.onComplete {
+      case Success(Some(lag)) =>
         self ! KTableProgressUpdate(assignedPartition, lag)
-      case None =>
+      case Success(None) =>
         log.debug(s"Could not find partition lag for partition $assignedPartition")
+      case Failure(exception) =>
+        log.debug(s"Could not find partition lag for partition $assignedPartition", exception)
     }
   }
 


### PR DESCRIPTION
The `lagChecker.getConsumerGroupLag` is a blocking call and also can potentially fail. Because of this, we should be wrapping in a future and properly handling any exceptions.