### PR TITLE
Add a flush record to avoid artificial lag from transactional markers

### DIFF
--- a/modules/command-engine/core/src/test/scala/surge/internal/kafka/KafkaProducerActorImplSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/kafka/KafkaProducerActorImplSpec.scala
@@ -27,8 +27,7 @@ import surge.health.domain.EmittableHealthSignal
 import surge.internal.akka.cluster.ActorSystemHostAwareness
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.internal.kafka.KafkaProducerActorImpl.{ AggregateStateRates, KTableProgressUpdate }
-import surge.kafka.streams.{ ExpectedTestException, HealthCheck }
-import surge.kafka.streams.HealthyActor.GetHealth
+import surge.kafka.streams.ExpectedTestException
 import surge.kafka.{ KafkaBytesProducer, KafkaRecordMetadata, LagInfo, PartitionAssignments }
 import surge.metrics.Metrics
 
@@ -92,6 +91,10 @@ class KafkaProducerActorImplSpec
           ArgumentMatchers.any(classOf[surge.health.domain.Error]),
           ArgumentMatchers.any(classOf[Map[String, String]])))
       .thenReturn(mockEmittable)
+
+    // Particular offset doesn't actually matter, we just want no lag
+    val mockMetadata = mockRecordMetadata(assignedPartition)
+    when(mockProducer.putRecord(any[ProducerRecord[String, Array[Byte]]])).thenReturn(Future.successful(mockMetadata))
 
     val actor =
       system.actorOf(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -31,7 +31,7 @@ object Settings extends AutoPlugin {
     })
 
   override def buildSettings: Seq[Def.Setting[_]] = Seq(
-    organization in ThisBuild := "com.ukg",
-    scalacOptions ++= Seq("-encoding", "UTF-8", "-unchecked", "-deprecation", "-feature"),
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD", "-u", "target/test-reports"))
+    ThisBuild / organization := "com.ukg",
+    scalacOptions ++= Seq("-encoding", "UTF-8", "-unchecked", "-deprecation", "-feature", "-Ywarn-unused"),
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oD", "-u", "target/test-reports"))
 }


### PR DESCRIPTION
In certain cases if transactional markers are the last things on a particular partition when the producer actor starts up, it will see those as the end offset for a topic while the KStreams process to index data won't progress past those offsets since there are no actual records there to be processed. This results in an artificial lag and the producer actor getting stuck in the `waitingForKTableIndexing` state