### PR TITLE
Docs: fix the BankAccountEngine

### DIFF
--- a/modules/surge-docs/src/test/scala/docs/command/BankAccountEngine.scala
+++ b/modules/surge-docs/src/test/scala/docs/command/BankAccountEngine.scala
@@ -10,6 +10,7 @@ import surge.scaladsl.command.SurgeCommand
 object BankAccountEngine {
   lazy val surgeEngine: SurgeCommand[UUID, BankAccount, BankAccountCommand, Nothing, BankAccountEvent] = {
     val engine = SurgeCommand(BankAccountSurgeModel)
+    engine.start()
     engine
   }
 }


### PR DESCRIPTION
If the surge engine is not started, it throws timeout exception