### PR TITLE
Explicitly respond with health check status from ProducerActor in fenced state

### DIFF
--- a/modules/command-engine/core/src/main/resources/reference.conf
+++ b/modules/command-engine/core/src/main/resources/reference.conf
@@ -29,6 +29,11 @@ kafka {
     ktable-check-interval = 500 milliseconds
     ktable-check-interval = ${?KAFKA_PUBLISHER_INITIALIZATION_INTERVAL}
 
+    # The amount of time the publisher actor is allotted to gracefully recover from receiving a ProducerFencedException
+    # before it should begin reporting as unhealthy via health checks
+    fenced-unhealthy-report-time = 60 seconds
+    fenced-unhealthy-report-time = ${?KAFKA_PUBLISHER_FENCED_UNHEALTHY_REPORT_TIME}
+
     init-transactions {
       # The time the producer actor will wait before attempting to re-initialize transactions when the broker returns an authorization exception
       authz-exception-retry-time = 1 minute
@@ -50,7 +55,7 @@ surge {
 
   health {
     bus {
-        stream-on-init = false
+      stream-on-init = false
     }
   }
 }

--- a/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/kafka/KafkaProducerActorImpl.scala
@@ -103,6 +103,7 @@ class KafkaProducerActorImpl(
     config.getDuration("kafka.publisher.init-transactions.authz-exception-retry-time").toMillis.millis.toCoarsest
   private val initTransactionOtherExceptionRetryDuration =
     config.getDuration("kafka.publisher.init-transactions.other-exception-retry-time").toMillis.millis.toCoarsest
+  private val producerFencedStateUnhealthyReportTime = config.getDuration("kafka.publisher.fenced-unhealthy-report-time").toMillis.milliseconds
 
   private val transactionalId = s"$transactionalIdPrefix-${assignedPartition.topic()}-${assignedPartition.partition()}"
   private val kafkaPublisherMetricsName = transactionalId
@@ -164,35 +165,46 @@ class KafkaProducerActorImpl(
   }
 
   private def uninitialized(lastProgressUpdate: Option[KTableProgressUpdate]): Receive = {
-    case CheckKTableProgress          => checkKTableProgress()
-    case InitTransactions             => initializeTransactions()
-    case InitTransactionSuccess       => initTransactionsSuccess(lastProgressUpdate)
-    case FlushMessages                => log.trace("KafkaPublisherActor ignoring FlushMessages message from the uninitialized state")
-    case GetHealth                    => doHealthCheck()
+    case CheckKTableProgress    => checkKTableProgress()
+    case InitTransactions       => initializeTransactions()
+    case InitTransactionSuccess => initTransactionsSuccess(lastProgressUpdate)
+    case FlushMessages          => log.trace("KafkaPublisherActor ignoring FlushMessages message from the uninitialized state")
+    case GetHealth =>
+      sender() ! HealthCheck(
+        name = "producer-actor",
+        id = assignedTopicPartitionKey,
+        status = HealthCheckStatus.UP,
+        details = Some(Map("state" -> "uninitialized")))
     case update: KTableProgressUpdate => context.become(uninitialized(lastProgressUpdate = Some(update)))
     case _: Publish                   => stash()
     case _: IsAggregateStateCurrent   => sender().tell(false, self)
   }
 
   private def waitingForKTableIndexing(): Receive = {
-    case CheckKTableProgress        => checkKTableProgress()
-    case msg: KTableProgressUpdate  => handleFromWaitingForKTableIndexingState(msg)
-    case FlushMessages              => log.trace("KafkaPublisherActor ignoring FlushMessages message from the waitingForKTableIndexing state")
-    case GetHealth                  => doHealthCheck()
+    case CheckKTableProgress       => checkKTableProgress()
+    case msg: KTableProgressUpdate => handleFromWaitingForKTableIndexingState(msg)
+    case FlushMessages             => log.trace("KafkaPublisherActor ignoring FlushMessages message from the waitingForKTableIndexing state")
+    case GetHealth =>
+      sender() ! HealthCheck(
+        name = "producer-actor",
+        id = assignedTopicPartitionKey,
+        status = HealthCheckStatus.UP,
+        details = Some(Map("state" -> "waitingForKTableIndexing")))
     case _: Publish                 => stash()
     case _: IsAggregateStateCurrent => sender().tell(false, self)
   }
 
-  private def fenced(state: KafkaProducerActorState): Receive = {
-    case msg: ProducerFenced => maybeRestartFencedProducer(state, msg)
+  private def fenced(state: KafkaProducerActorState, initialFenceTime: Instant): Receive = {
+    case msg: ProducerFenced => maybeRestartFencedProducer(msg)
     case msg: EventsFailedToPublish =>
-      context.become(fenced(state.completeTransaction()))
+      context.become(fenced(state.completeTransaction(), initialFenceTime))
       msg.originalSenders.foreach(_ ! KafkaProducerActor.PublishFailure(msg.reason))
     case RestartProducer              => restartPublisher()
     case ShutdownProducer             => context.stop(self)
     case CheckKTableProgress          => log.trace("KafkaPublisherActor ignoring CheckKTableProgress message from the fenced state")
     case FlushMessages                => log.trace("KafkaPublisherActor ignoring FlushMessages message from the fenced state")
-    case update: KTableProgressUpdate => context.become(fenced(state.processedUpTo(update)))
+    case update: KTableProgressUpdate => context.become(fenced(state.processedUpTo(update), initialFenceTime))
+    case GetHealth                    => doHealthCheck(initialFenceTime)
     case _                            => stash()
   }
 
@@ -206,7 +218,8 @@ class KafkaProducerActorImpl(
 
   private def handleProcessingProducerMessage(message: KafkaProducerActorImpl.KafkaProducerActorMessage, state: KafkaProducerActorState): Unit = {
     message match {
-      case msg: Publish                 => handle(state, msg)
+      case msg: Publish =>
+        context.become(processing(state.addPendingWrites(sender(), msg)))
       case msg: IsAggregateStateCurrent => handle(state, msg)
       case other                        => unhandled(other)
     }
@@ -215,13 +228,13 @@ class KafkaProducerActorImpl(
   private def handleProcessingInternalMessage(message: InternalMessage, state: KafkaProducerActorState): Unit = {
     message match {
       case CheckKTableProgress         => checkKTableProgress()
-      case msg: KTableProgressUpdate   => handle(state, msg)
+      case msg: KTableProgressUpdate   => context.become(processing(state.processedUpTo(msg)))
       case msg: EventsPublished        => handle(state, msg)
       case msg: EventsFailedToPublish  => handleFailedToPublish(state, msg)
       case FlushMessages               => handleFlushMessages(state)
       case msg: AbortTransactionFailed => handle(msg)
       case msg: ProducerFenced =>
-        context.become(fenced(state))
+        context.become(fenced(state, Instant.now))
         self ! msg
       case other => unhandled(other)
     }
@@ -282,14 +295,6 @@ class KafkaProducerActorImpl(
     kafkaPublisher = getPublisher
   }
 
-  private def handle(state: KafkaProducerActorState, publish: Publish): Unit = {
-    context.become(processing(state.addPendingWrites(sender(), publish)))
-  }
-
-  private def handle(state: KafkaProducerActorState, kTableProgressUpdate: KTableProgressUpdate): Unit = {
-    context.become(processing(state.processedUpTo(kTableProgressUpdate)))
-  }
-
   private def handleFromWaitingForKTableIndexingState(kTableProgressUpdate: KTableProgressUpdate): Unit = {
     val currentLag = kTableProgressUpdate.lagInfo.offsetLag
     if (currentLag == 0L) {
@@ -313,8 +318,6 @@ class KafkaProducerActorImpl(
     msg.originalSenders.foreach(_ ! KafkaProducerActor.PublishFailure(msg.reason))
   }
 
-  // FIXME need to open a GH issue for this warning
-  private var lastTransactionInProgressWarningTime: Instant = Instant.ofEpochMilli(0L)
   private val eventsPublishedRate: Rate = metrics.rate(
     MetricInfo(
       name = s"surge.${aggregateName.toLowerCase()}.event-publish-rate",
@@ -323,14 +326,15 @@ class KafkaProducerActorImpl(
   private def handleFlushMessages(state: KafkaProducerActorState): Unit = {
     if (state.transactionInProgress) {
       if (state.currentTransactionTimeMillis >= transactionTimeWarningThresholdMillis &&
-        lastTransactionInProgressWarningTime.plusMillis(transactionTimeWarningThresholdMillis).isBefore(Instant.now())) {
-        lastTransactionInProgressWarningTime = Instant.now
+        state.lastTransactionInProgressWarningTime.plusMillis(transactionTimeWarningThresholdMillis).isBefore(Instant.now())) {
+        val newState = state.copy(lastTransactionInProgressWarningTime = Instant.now)
         log.warn(
           s"KafkaPublisherActor partition {} tried to flush, but another transaction is already in progress. " +
             s"The previous transaction has been in progress for {} milliseconds. If the time to complete the previous transaction continues to grow " +
             s"that typically indicates slowness in the Kafka brokers.",
           assignedPartition,
           state.currentTransactionTimeMillis)
+        context.become(processing(newState))
       }
     } else if (state.pendingWrites.nonEmpty) {
       val eventMessages = state.pendingWrites.flatMap(_.publish.eventsToPublish)
@@ -361,7 +365,7 @@ class KafkaProducerActorImpl(
     val futureMsg = kafkaPublisherTimer.timeFuture {
       Try(kafkaPublisher.beginTransaction()) match {
         case Failure(f: ProducerFencedException) =>
-          producerFenced(state, f)
+          producerFenced(f)
           Future.successful(EventsFailedToPublish(senders, f))
         case Failure(err) =>
           log.error(s"KafkaPublisherActor partition $assignedPartition there was an error beginning transaction", err)
@@ -376,7 +380,7 @@ class KafkaProducerActorImpl(
             }
             .recover {
               case e: ProducerFencedException =>
-                producerFenced(state, e)
+                producerFenced(e)
                 EventsFailedToPublish(senders, e)
               case e =>
                 log.error(s"KafkaPublisherActor partition $assignedPartition got error while trying to publish to Kafka", e)
@@ -407,7 +411,7 @@ class KafkaProducerActorImpl(
     context.become(uninitialized(None))
   }
 
-  private def producerFenced(state: KafkaProducerActorState, exception: ProducerFencedException): Unit = {
+  private def producerFenced(exception: ProducerFencedException): Unit = {
     val producerFencedErrorLog = s"KafkaPublisherActor partition $assignedPartition tried to commit a transaction, but was " +
       s"fenced out by another producer instance. This instance of the producer for the assigned partition will shut down in favor of the " +
       s"newer producer for this partition.  If this message persists, check that two independent application clusters are not using the same " +
@@ -416,7 +420,7 @@ class KafkaProducerActorImpl(
     self ! ProducerFenced(exception)
   }
 
-  private def maybeRestartFencedProducer(state: KafkaProducerActorState, fenced: ProducerFenced): Unit = {
+  private def maybeRestartFencedProducer(fenced: ProducerFenced): Unit = {
     implicit val timeout: Timeout = Timeout(10.seconds)
     partitionTracker.getPartitionAssignments
       .map { assignments =>
@@ -447,8 +451,18 @@ class KafkaProducerActorImpl(
     }
   }
 
-  private def doHealthCheck(): Unit = {
-    val healthCheck = HealthCheck(name = "producer-actor", id = assignedTopicPartitionKey, status = HealthCheckStatus.UP)
+  private def doHealthCheck(initialFenceTime: Instant): Unit = {
+    val timeSinceFenceMs = Instant.now.toEpochMilli - initialFenceTime.toEpochMilli
+    val healthStatus = if (timeSinceFenceMs >= producerFencedStateUnhealthyReportTime.toMillis) {
+      HealthCheckStatus.DOWN
+    } else {
+      HealthCheckStatus.UP
+    }
+    val healthCheck = HealthCheck(
+      name = "producer-actor",
+      id = assignedTopicPartitionKey,
+      status = healthStatus,
+      details = Some(Map("state" -> "fenced", "millisecondsSinceFenced" -> timeSinceFenceMs.toString)))
     sender() ! healthCheck
   }
 
@@ -469,14 +483,15 @@ class KafkaProducerActorImpl(
         Map(
           "inFlight" -> state.inFlight.size.toString,
           "pendingWrites" -> state.pendingWrites.size.toString,
-          "currentTransactionTimeMillis" -> state.currentTransactionTimeMillis.toString)))
+          "currentTransactionTimeMillis" -> state.currentTransactionTimeMillis.toString,
+          "state" -> "processing")))
     sender() ! healthCheck
   }
 }
 
 private[internal] object KafkaProducerActorState {
-  def empty(implicit sender: ActorRef, rates: KafkaProducerActorImpl.AggregateStateRates): KafkaProducerActorState = {
-    KafkaProducerActorState(Seq.empty, Seq.empty, transactionInProgressSince = None, sender = sender, rates = rates)
+  def empty: KafkaProducerActorState = {
+    KafkaProducerActorState(Seq.empty, Seq.empty, transactionInProgressSince = None)
   }
 }
 // TODO optimize:
@@ -485,12 +500,10 @@ private[internal] case class KafkaProducerActorState(
     inFlight: Seq[KafkaRecordMetadata[String]],
     pendingWrites: Seq[KafkaProducerActorImpl.PublishWithSender],
     transactionInProgressSince: Option[Instant],
-    sender: ActorRef,
-    rates: KafkaProducerActorImpl.AggregateStateRates) {
+    lastTransactionInProgressWarningTime: Instant = Instant.ofEpochMilli(0L)) {
 
   import KafkaProducerActorImpl._
 
-  private implicit val senderActor: ActorRef = sender
   private val log: Logger = LoggerFactory.getLogger(getClass)
 
   def transactionInProgress: Boolean = transactionInProgressSince.nonEmpty

--- a/modules/common/src/main/resources/reference.conf
+++ b/modules/common/src/main/resources/reference.conf
@@ -194,50 +194,6 @@ surge {
     enable-kafka-metrics = ${?SURGE_KAFKA_STREAMS_ENABLE_KAFKA_METRICS}
   }
 
-  kafka-event-source {
-    committer {
-      max-batch = 1000
-      max-batch = ${?SURGE_KAFKA_EVENT_SOURCE_COMMITTER_MAX_BATCH}
-
-      max-interval = 10s
-      max-interval = ${?SURGE_KAFKA_EVENT_SOURCE_COMMITTER_MAX_INTERVAL}
-
-      parallelism = 100
-      parallelism = ${?SURGE_KAFKA_EVENT_SOURCE_COMMITTER_PARALLELISM}
-    }
-
-    consumer {
-      auto-offset-reset = "earliest"
-      auto-offset-reset = ${?SURGE_KAFKA_EVENT_SOURCE_CONSUMER_AUTO_OFFSET_RESET}
-
-      session-timeout = 10 seconds
-      session-timeout = ${?SURGE_KAFKA_EVENT_SOURCE_CONSUMER_SESSION_TIMEOUT}
-
-      partition-assignor = "range"
-      partition-assignor = ${?SURGE_KAFKA_EVENT_SOURCE_CONSUMER_PARTITION_ASSIGNOR}
-    }
-
-    backoff {
-      min = 1 second
-      min = ${?SURGE_KAFKA_EVENT_SOURCE_BACKOFF_MIN}
-
-      max = 10 seconds
-      max = ${?SURGE_KAFKA_EVENT_SOURCE_BACKOFF_MAX}
-
-      random-factor = 0.1
-      random-factor = ${?SURGE_KAFKA_EVENT_SOURCE_BACKOFF_RANDOM_FACTOR}
-    }
-
-    kafka-metric-fetch-timeout = 15 seconds
-    kafka-metric-fetch-timeout = ${?SURGE_KAFKA_EVENT_SOURCE_METRIC_FETCH_TIMEOUT}
-
-    enable-kafka-metrics = true
-    enable-kafka-metrics = ${?SURGE_KAFKA_EVENT_SOURCE_ENABLE_KAFKA_METRICS}
-  }
-
-  kafka-reuse-consumer-id = false
-  kafka-reuse-consumer-id = ${?SURGE_KAFKA_REUSE_CONSUMER_GROUP_ID}
-
   health {
    signal-pattern-matcher-registry {}
    bus {

--- a/modules/common/src/test/resources/application.conf
+++ b/modules/common/src/test/resources/application.conf
@@ -1,3 +1,0 @@
-surge {
-  kafka-reuse-consumer-id = true # Set this to true for some of the tests around EventSource stream restarts
-}


### PR DESCRIPTION
The producer actor fails to get health checks in some cases with a "failed to get producer actor health check" message. This can happen either if the actor crashes or if the actor is in the fenced state and just stashes health check messages without replying. With this change we will no longer stash health check messages in the fenced state and instead report health explicitly. The health check in the fenced state will report UP until we've been in the fenced state for longer than `kafka.publisher.fenced-unhealthy-report-time` (default 60 seconds) to give it a chance to attempt automatic recovery. Once it's been in the fenced state for longer, the health check will report as DOWN.