### PR TITLE
Fix javadsl AsyncAggregateCommandModel

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/AggregateProcessingModel.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/AggregateProcessingModel.scala
@@ -5,7 +5,7 @@ package surge.internal.domain
 import surge.internal.persistence.Context
 
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
 /**
  * The result of handling a message
@@ -47,26 +47,7 @@ trait AggregateProcessingModel[S, M, +R, E] {
    */
   def handle(ctx: Context, state: Option[S], msg: M)(implicit ec: ExecutionContext): Future[Either[R, HandledMessageResult[S, E]]]
 
-  /**
-   * Apply an event. Apply event to state and return the resulting state.
-   * @param ctx
-   *   a context object for interacting with the X-engine.
-   * @param state
-   *   the current state of the aggregate
-   * @param event
-   *   the event to apply
-   * @return
-   *   the resulting state
-   */
-  def apply(ctx: Context, state: Option[S], event: E): Option[S]
-
-  def applyAsync(ctx: Context, state: Option[S], event: E): Future[Option[S]] = {
-    Try(apply(ctx, state, event)) match {
-      case Failure(exception) => Future.failed(exception)
-      case Success(value)     => Future.successful(value)
-    }
-  }
-
+  def applyAsync(ctx: Context, state: Option[S], event: E): Future[Option[S]]
 }
 
 trait CommandHandler[S, M, R, E] extends AggregateProcessingModel[S, M, R, E] {
@@ -74,11 +55,18 @@ trait CommandHandler[S, M, R, E] extends AggregateProcessingModel[S, M, R, E] {
 
   def processCommand(ctx: Context, state: Option[S], cmd: M): Future[CommandResult]
 
+  def apply(ctx: Context, state: Option[S], event: E): Option[S]
+  // FIXME this is a bit awkward. We should have a pure synchronous model, pure async model, and maybe something else for the gRPC pieces.
+  //       Perhaps it could implement AggregateProcessingModel directly
+  def applyAsync(ctx: Context, state: Option[S], event: E): Future[Option[S]] = Future.fromTry(Try(apply(ctx, state, event)))
+
   override def handle(ctx: Context, state: Option[S], cmd: M)(implicit ec: ExecutionContext): Future[Either[R, HandledMessageResult[S, E]]] =
-    processCommand(ctx, state, cmd).map {
-      case Left(rejected) => Left(rejected)
+    processCommand(ctx, state, cmd).flatMap {
+      case Left(rejected) => Future.successful(Left(rejected))
       case Right(events) =>
-        Right(HandledMessageResult(events.foldLeft(state)((s: Option[S], e: E) => apply(ctx, s, e)), events))
+        events.foldLeft(Future.successful(state))((s: Future[Option[S]], e: E) => s.flatMap(prev => applyAsync(ctx, prev, e))).map { resultingState =>
+          Right(HandledMessageResult(resultingState = resultingState, eventsToLog = events))
+        }
     }
 }
 
@@ -112,7 +100,7 @@ trait EventHandler[S, E] extends AggregateProcessingModel[S, Nothing, Nothing, E
       implicit ec: ExecutionContext): Future[Either[Nothing, HandledMessageResult[S, Nothing]]] =
     throw new RuntimeException("Impossible")
 
-  override final def apply(ctx: Context, state: Option[S], event: E): Option[S] = handleEvent(ctx, state, event)
+  override def applyAsync(ctx: Context, state: Option[S], event: E): Future[Option[S]] = Future.fromTry(Try(handleEvent(ctx, state, event)))
 }
 
 trait AsyncEventHandler[S, E] extends EventHandler[S, E] {


### PR DESCRIPTION
With all the layering happening the internal `CommandHandler` was calling the abstract `apply` (non-async) method, which was implemented to throw an exception in the `AsyncAggregateCommandModel` since the async version should be called instead.