### PR TITLE
Add Concurrency setting to GH Workflows

### DIFF
--- a/.github/workflows/surge-ci.yml
+++ b/.github/workflows/surge-ci.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change will cause previous in-progress builds to cancel whenever a push is made to the PR branch