### PR TITLE
Remove some unused configuration related to replay

### DIFF
--- a/modules/common/src/main/resources/reference.conf
+++ b/modules/common/src/main/resources/reference.conf
@@ -61,16 +61,6 @@ kafka {
       statistics-interval-seconds = 600
       statistics-interval-seconds = ${?KAFKA_STREAMS_ROCKSDB_STATISTICS_INTERVAL_SECONDS}
     }
-
-    replay {
-      reset-topic-timeout = 30 seconds
-      reset-topic-timeout = ${?KAFKA_STREAMS_REPLAY_RESET_TOPIC_TIMEOUT}
-      check-progress-init-delay = 1 seconds
-      check-progress-poll-time = 30 seconds
-      check-progress-poll-time = ${?KAFKA_STREAMS_REPLAY_CHECK_PROGRESS_POLL_TIME}
-      entire-process-timeout = 60 seconds
-      entire-process-timeout = ${?KAFKA_STREAMS_REPLAY_TIMEOUT}
-    }
   }
 
   brokers = "localhost:9092"

--- a/modules/common/src/main/scala/surge/exceptions/SurgeReplayException.scala
+++ b/modules/common/src/main/scala/surge/exceptions/SurgeReplayException.scala
@@ -1,5 +1,0 @@
-// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
-
-package surge.exceptions
-
-class SurgeReplayException(message: String) extends RuntimeException(message)

--- a/modules/common/src/main/scala/surge/internal/config/TimeoutConfig.scala
+++ b/modules/common/src/main/scala/surge/internal/config/TimeoutConfig.scala
@@ -11,10 +11,6 @@ import scala.concurrent.duration._
 object TimeoutConfig {
   private val config = ConfigFactory.load()
 
-  object ReplayCoordinatorActor {
-    val actorAskTimeout: FiniteDuration = 30.seconds
-  }
-
   object StateStoreKafkaStreamActor {
     val askTimeout: FiniteDuration =
       config.getDuration("surge.state-store-actor.ask-timeout", TimeUnit.MILLISECONDS).milliseconds

--- a/modules/common/src/main/scala/surge/internal/utils/MdcExecutionContext.scala
+++ b/modules/common/src/main/scala/surge/internal/utils/MdcExecutionContext.scala
@@ -1,3 +1,5 @@
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
 package surge.internal.utils
 
 object MdcExecutionContext {

--- a/modules/common/src/main/scala/surge/internal/utils/MdcFuturePropagation.scala
+++ b/modules/common/src/main/scala/surge/internal/utils/MdcFuturePropagation.scala
@@ -1,3 +1,5 @@
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
 package surge.internal.utils
 
 import org.slf4j.MDC

--- a/modules/common/src/test/scala/surge/internal/utils/MdcFuturePropagationSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/utils/MdcFuturePropagationSpec.scala
@@ -1,3 +1,5 @@
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
 package surge.internal.utils
 
 import org.scalatest.concurrent.ScalaFutures

--- a/modules/multilanguage/src/main/scala/com/ukg/surge/multilanguage/GenericSurgeCommandBusinessLogic.scala
+++ b/modules/multilanguage/src/main/scala/com/ukg/surge/multilanguage/GenericSurgeCommandBusinessLogic.scala
@@ -1,4 +1,6 @@
 // Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
+
+// Copyright © 2017-2021 UKG Inc. <https://www.ukg.com>
 package com.ukg.surge.multilanguage
 
 import akka.actor.ActorSystem


### PR DESCRIPTION
Replay functionality no longer exists in this repository so it doesn't make sense for the configuration of it to hang around. Also runs `sbt codeFormat` to fix headers in a couple of files