### PR TITLE
Properly Propagate MDC and Spans Across Nodes & Execution Contexts

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -102,7 +102,7 @@ class KafkaProducerActor(
     override val signalBus: HealthSignalBusTrait)
     extends HealthyComponent
     with HealthSignalBusAware {
-  private implicit val executionContext: ExecutionContext = ExecutionContext.global
+  private implicit val executionContext: ExecutionContext = new DiagnosticContextFuturePropagation(ExecutionContext.global)
   private val log = LoggerFactory.getLogger(getClass)
 
   def publish(
@@ -110,7 +110,7 @@ class KafkaProducerActor(
       state: KafkaProducerActor.MessageToPublish,
       events: Seq[KafkaProducerActor.MessageToPublish]): Future[KafkaProducerActor.PublishResult] = {
     log.trace(s"Publishing state for {} {}", Seq(aggregateName, state.key): _*)
-    implicit val ec: ExecutionContext = ExecutionContext.global
+    implicit val ec: ExecutionContext = new DiagnosticContextFuturePropagation(ExecutionContext.global)
     implicit val askTimeout: Timeout = Timeout(TimeoutConfig.PublisherActor.publishTimeout)
     (publisherActor.ref ? KafkaProducerActorImpl.Publish(eventsToPublish = events, state = state)).mapTo[KafkaProducerActor.PublishResult]
   }

--- a/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeGenericBusinessLogicTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/commondsl/SurgeGenericBusinessLogicTrait.scala
@@ -7,6 +7,7 @@ import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting }
 import surge.internal.tracing.OpenTelemetryInstrumentation
+import surge.internal.utils.DiagnosticContextFuturePropagation
 import surge.kafka.{ KafkaPartitioner, KafkaTopic, PartitionStringUpToColon }
 import surge.metrics.Metrics
 
@@ -58,5 +59,5 @@ trait SurgeGenericBusinessLogicTrait[AggId, Agg, Command, Rej, Event] {
 
   def transactionalIdPrefix: String = "surge-transactional-event-producer-partition"
 
-  val executionContext: ExecutionContext = global
+  val executionContext: ExecutionContext = new DiagnosticContextFuturePropagation(global)
 }

--- a/modules/command-engine/core/src/main/scala/surge/internal/SurgeModel.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/SurgeModel.scala
@@ -5,6 +5,7 @@ package surge.internal
 import surge.core.{ SurgeAggregateReadFormatting, SurgeAggregateWriteFormatting, SurgeEventWriteFormatting }
 import surge.internal.domain.AggregateProcessingModel
 import surge.internal.kafka.ProducerActorContext
+import surge.internal.utils.DiagnosticContextFuturePropagation
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
@@ -14,5 +15,5 @@ trait SurgeModel[S, M, +R, E] extends ProducerActorContext {
   def aggregateWriteFormatting: SurgeAggregateWriteFormatting[S]
   def eventWriteFormattingOpt: Option[SurgeEventWriteFormatting[E]]
   def model: AggregateProcessingModel[S, M, R, E]
-  val executionContext: ExecutionContext = global
+  val executionContext: ExecutionContext = new DiagnosticContextFuturePropagation(global)
 }

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -13,6 +13,7 @@ import surge.internal.SurgeModel
 import surge.internal.akka.kafka.KafkaConsumerPartitionAssignmentTracker
 import surge.internal.config.TimeoutConfig
 import surge.internal.persistence.RoutableMessage
+import surge.internal.utils.DiagnosticContextFuturePropagation
 import surge.kafka.streams.{ HealthCheck, HealthCheckStatus, HealthyActor, HealthyComponent }
 import surge.kafka.{ KafkaPartitionShardRouterActor, PersistentActorRegionCreator }
 
@@ -29,7 +30,7 @@ private[surge] final class SurgePartitionRouterImpl(
     extends SurgePartitionRouter
     with HealthyComponent
     with Controllable {
-  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val executionContext: ExecutionContext = new DiagnosticContextFuturePropagation(system.dispatcher)
   private val log = LoggerFactory.getLogger(getClass)
 
   private val shardRouterProps = KafkaPartitionShardRouterActor.props(

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
@@ -13,6 +13,7 @@ import surge.internal.akka.cluster.ActorSystemHostAwareness
 import surge.internal.akka.kafka.{ CustomConsumerGroupRebalanceListener, KafkaConsumerPartitionAssignmentTracker, KafkaConsumerStateTrackingActor }
 import surge.internal.health.HealthSignalStreamProvider
 import surge.internal.persistence.PersistentActorRegionCreator
+import surge.internal.utils.DiagnosticContextFuturePropagation
 import surge.kafka.PartitionAssignments
 import surge.kafka.streams._
 
@@ -65,7 +66,8 @@ private[surge] abstract class SurgeMessagePipeline[S, M, +R, E](
 
   protected val actorRouter: SurgePartitionRouter = SurgePartitionRouter(config, actorSystem, partitionTracker, businessLogic, cqrsRegionCreator, signalBus)
 
-  protected val surgeHealthCheck: SurgeHealthCheck = new SurgeHealthCheck(businessLogic.aggregateName, kafkaStreamsImpl, actorRouter)(ExecutionContext.global)
+  protected val surgeHealthCheck: SurgeHealthCheck = new SurgeHealthCheck(businessLogic.aggregateName, kafkaStreamsImpl, actorRouter)(
+    new DiagnosticContextFuturePropagation(ExecutionContext.global))
 
   override def healthCheck(): Future[HealthCheck] = {
     surgeHealthCheck.healthCheck()

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/KTablePersistenceSupport.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/KTablePersistenceSupport.scala
@@ -10,6 +10,7 @@ import io.opentelemetry.api.trace.Span
 import org.slf4j.LoggerFactory
 import surge.core.KafkaProducerActor
 import surge.exceptions.KafkaPublishTimeoutException
+import surge.internal.utils.DiagnosticContextFuturePropagation
 import surge.metrics.Timer
 
 import java.time.Instant
@@ -86,7 +87,7 @@ trait KTablePersistenceSupport[Agg, Event] {
   }
 
   private def handleFailedToPersist(state: ActorState, eventsFailedToPersist: PersistenceFailure): Unit = {
-    implicit val ec: ExecutionContext = context.dispatcher
+    implicit val ec: ExecutionContext = new DiagnosticContextFuturePropagation(context.dispatcher)
 
     if (eventsFailedToPersist.numberOfFailures > maxProducerFailureRetries) {
       ktablePersistenceMetrics.eventPublishTimer.recordTime(publishTimeInMillis(eventsFailedToPersist.startTime))

--- a/modules/common/src/main/scala/surge/internal/akka/cluster/Shard.scala
+++ b/modules/common/src/main/scala/surge/internal/akka/cluster/Shard.scala
@@ -15,8 +15,7 @@ import surge.kafka.streams.HealthyActor.GetHealth
 import surge.kafka.streams.{ HealthCheck, HealthCheckStatus }
 import surge.internal.tracing.TracedMessage
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
 /**
@@ -43,6 +42,8 @@ object Shard {
 class Shard[IdType](shardId: String, regionLogicProvider: PerShardLogicProvider[IdType], extractEntityId: PartialFunction[Any, IdType])(
     implicit val tracer: Tracer)
     extends ActorWithTracing {
+
+  implicit val ec: ExecutionContext = context.dispatcher
 
   private val log: Logger = LoggerFactory.getLogger(getClass)
   private val bufferSize = 1000

--- a/modules/common/src/main/scala/surge/internal/utils/DiagnosticContextFuturePropagation.scala
+++ b/modules/common/src/main/scala/surge/internal/utils/DiagnosticContextFuturePropagation.scala
@@ -2,10 +2,11 @@
 
 package surge.internal.utils
 
-import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.{ Span, Tracer }
+import io.opentelemetry.context.Context
 import org.slf4j.MDC
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 
 /**
  * Execution context proxy for propagating SLF4J diagnostic context and the current span from caller thread to execution thread.
@@ -14,15 +15,20 @@ class DiagnosticContextFuturePropagation(executionContext: ExecutionContext) ext
   override def execute(runnable: Runnable): Unit = {
     val callerMdc = Option(MDC.getCopyOfContextMap) // get a copy of the MDC context data
     val callerSpan = Span.current()
+    println(s"JEFF --- caller MDC = $callerMdc")
+    println(s"JEFF --- caller span = $callerSpan")
     executionContext.execute(new Runnable {
       def run(): Unit = {
         callerMdc.foreach(MDC.setContextMap)
-        callerSpan.makeCurrent()
+        val scope = callerSpan.makeCurrent()
         try {
+          println(s"JEFF --- calling run() - scope = $scope, MDC = ${MDC.getCopyOfContextMap}")
           runnable.run()
         } finally {
           // the thread might be reused, so we clean up for the next use
+          println("JEFF --- cleaning up future thread")
           MDC.clear()
+          scope.close()
         }
       }
     })

--- a/modules/common/src/main/scala/surge/kafka/streams/ThreadPools.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/ThreadPools.scala
@@ -2,11 +2,13 @@
 
 package surge.kafka.streams
 
-import java.util.concurrent.Executors
+import surge.internal.utils.DiagnosticContextFuturePropagation
 
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext
 
 object ThreadPools {
   private val ioBoundThreadPoolSize: Int = 32
-  val ioBoundContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(ioBoundThreadPoolSize))
+  val ioBoundContext: ExecutionContext = new DiagnosticContextFuturePropagation(
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(ioBoundThreadPoolSize)))
 }

--- a/modules/common/src/test/scala/surge/internal/utils/DiagnosticContextFuturePropagationSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/utils/DiagnosticContextFuturePropagationSpec.scala
@@ -35,6 +35,19 @@ class DiagnosticContextFuturePropagationSpec extends AnyFlatSpec with ScalaFutur
     whenReady(futureRequestId) { requestId =>
       requestId mustEqual id
     }
+
+    val doubleFutureRequestId = Future {
+      "something"
+    }.flatMap { _ =>
+      Future {
+        logger.info(s"future requestId propagated: ${MDC.get("requestId")}")
+        MDC.get("requestId")
+      }
+    }
+
+    whenReady(doubleFutureRequestId) { requestId =>
+      requestId mustEqual id
+    }
   }
 
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -94,7 +94,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   <parameter name="maxMethods"><![CDATA[40]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>


### PR DESCRIPTION
Propagates spans and MDC across various execution contexts so that the business logic can properly create child spans and so that traces are able to be continued when executing on different threads.