### PR TITLE
Make it so the controllable instance doesn't leak through to the DSL

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/KafkaProducerActor.scala
@@ -158,7 +158,7 @@ class KafkaProducerActor(
       log.error(s"Unable to register $getClass for supervision", error)
   }
 
-  override def controllable: Controllable = new Controllable {
+  private[surge] override val controllable: Controllable = new Controllable {
 
     override def start(): Future[Ack] = {
       publisherActor.start().andThen(registrationCallback())

--- a/modules/command-engine/core/src/main/scala/surge/core/SurgeProcessingTrait.scala
+++ b/modules/command-engine/core/src/main/scala/surge/core/SurgeProcessingTrait.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import surge.internal.SurgeModel
 
 trait SurgeProcessingTrait[S, M, +R, E] {
-  def controllable: Controllable
+  private[surge] def controllable: Controllable
   val businessLogic: SurgeModel[S, M, R, E]
   def actorSystem: ActorSystem
   def config: Config

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -56,7 +56,7 @@ private[surge] final class SurgePartitionRouterImpl(
       }
   }
 
-  override def controllable: Controllable = new Controllable {
+  private[surge] override val controllable: Controllable = new Controllable {
     override def start(): Future[Ack] = {
       // TODO explicit start/stop for router actor
       //implicit val askTimeout: Timeout = Timeout(TimeoutConfig.PartitionRouter.askTimeout)

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
@@ -135,7 +135,7 @@ private[surge] abstract class SurgeMessagePipeline[S, M, +R, E](
       }(system.dispatcher)
   }
 
-  override def controllable: Controllable = new Controllable {
+  private[surge] override val controllable: Controllable = new Controllable {
     override def start(): Future[Ack] = {
       implicit val ec: ExecutionContext = system.dispatcher
       val result = for {

--- a/modules/command-engine/core/src/main/scala/surge/internal/persistence/PersistentActorRegion.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/persistence/PersistentActorRegion.scala
@@ -92,7 +92,7 @@ class PersistentActorRegion[M](
       log.error(s"Unable to register ${this.getClass} for supervision", error)
   }
 
-  override def controllable: Controllable = new Controllable {
+  private[surge] override val controllable: Controllable = new Controllable {
     override def start(): Future[Ack] = kafkaProducerActor.controllable.start().andThen(registrationCallback())(ExecutionContext.global)
 
     override def restart(): Future[Ack] = {

--- a/modules/common/src/main/scala/surge/internal/akka/kafka/KafkaConsumerStateTrackingActor.scala
+++ b/modules/common/src/main/scala/surge/internal/akka/kafka/KafkaConsumerStateTrackingActor.scala
@@ -27,7 +27,7 @@ class KafkaConsumerPartitionAssignmentTracker(val underlyingActor: ActorRef) ext
     underlyingActor.ask(HealthyActor.GetHealth)(TimeoutConfig.HealthCheck.actorAskTimeout).mapTo[HealthCheck]
   }
 
-  override def controllable: Controllable = new ControllableAdapter()
+  override val controllable: Controllable = new ControllableAdapter()
 }
 
 object KafkaConsumerStateTrackingActor {

--- a/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
@@ -165,7 +165,7 @@ class AggregateStateStoreKafkaStreams[Agg >: Null](
       log.error("Failed to stop so unable to unregister from supervision", exception)
   }
 
-  override def controllable: Controllable = new Controllable {
+  override val controllable: Controllable = new Controllable {
     override def start(): Future[Ack] = {
       implicit val ec: ExecutionContext = system.dispatcher
       underlyingActor.ask(ActorLifecycleManagerActor.Start).mapTo[Ack].andThen(registrationCallback())

--- a/modules/common/src/main/scala/surge/kafka/streams/SurgeHealthCheck.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/SurgeHealthCheck.scala
@@ -71,7 +71,7 @@ trait HealthyComponent {
    */
   def shutdownSignalPatterns(): Seq[Pattern] = Seq.empty
 
-  def controllable: Controllable
+  private[surge] def controllable: Controllable
 }
 
 case class HealthCheck(

--- a/modules/common/src/test/scala/surge/internal/akka/cluster/ShardSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/akka/cluster/ShardSpec.scala
@@ -51,7 +51,7 @@ object TestActor {
     override def onShardTerminated(): Unit =
       onShardTerminatedCallback()
 
-    override def controllable: Controllable = new ControllableAdapter
+    private[surge] override val controllable: Controllable = new ControllableAdapter
   }
 }
 

--- a/modules/common/src/test/scala/surge/kafka/KafkaPartitionShardRouterActorSpec.scala
+++ b/modules/common/src/test/scala/surge/kafka/KafkaPartitionShardRouterActorSpec.scala
@@ -43,7 +43,7 @@ object KafkaPartitionShardRouterActorSpecModels {
         override def onShardTerminated(): Unit = {}
         override def healthCheck(): Future[HealthCheck] = Future.successful(HealthCheck("test", "test", HealthCheckStatus.UP))
 
-        override def controllable: Controllable = new ControllableAdapter
+        override val controllable: Controllable = new ControllableAdapter
       }
 
       provider.controllable.start()


### PR DESCRIPTION
Originally I was thinking it was a big problem that a new instance of `Controllable` was created each time `controllable` was called.  It turns out that since what is created is really an anonymous inner class with no state of its own, its not a huge problem but just a slight waste of resources due to the extraneous object creation.  However, I also realized that the `controllable` method was being leaked through to the DSL.  This PR addresses both by making it a `val` rather than a `def` and making it private to the `surge` package.