### PR TITLE
HealthSupervisor shall keep track of registered components by ID

### DIFF
--- a/modules/common/src/main/scala/surge/health/supervisor/Api.scala
+++ b/modules/common/src/main/scala/surge/health/supervisor/Api.scala
@@ -5,6 +5,7 @@ package surge.health.supervisor
 import akka.actor.{ ActorRef, NoSerializationVerificationNeeded }
 import surge.health.supervisor.Domain.SupervisedComponentRegistration
 
+import java.util.UUID
 import java.util.regex.Pattern
 
 object Api {
@@ -19,13 +20,14 @@ object Api {
 
   case class UnregisterSupervisedComponentRequest(componentName: String) extends NoSerializationVerificationNeeded
   case class RegisterSupervisedComponentRequest(
+      id: UUID,
       componentName: String,
       controlProxyRef: ActorRef,
       restartSignalPatterns: Seq[Pattern],
       shutdownSignalPatterns: Seq[Pattern])
       extends NoSerializationVerificationNeeded {
     def asSupervisedComponentRegistration(): SupervisedComponentRegistration =
-      SupervisedComponentRegistration(componentName, controlProxyRef, restartSignalPatterns, shutdownSignalPatterns)
+      SupervisedComponentRegistration(id, componentName, controlProxyRef, restartSignalPatterns, shutdownSignalPatterns)
   }
 
   case class HealthRegistrationDetailsRequest() extends NoSerializationVerificationNeeded

--- a/modules/common/src/main/scala/surge/health/supervisor/Domain.scala
+++ b/modules/common/src/main/scala/surge/health/supervisor/Domain.scala
@@ -4,10 +4,12 @@ package surge.health.supervisor
 
 import akka.actor.ActorRef
 
+import java.util.UUID
 import java.util.regex.Pattern
 
 object Domain {
   case class SupervisedComponentRegistration(
+      id: UUID,
       componentName: String,
       controlProxyRef: ActorRef,
       restartSignalPatterns: Seq[Pattern],

--- a/modules/common/src/main/scala/surge/internal/health/HealthSignalBus.scala
+++ b/modules/common/src/main/scala/surge/internal/health/HealthSignalBus.scala
@@ -334,7 +334,7 @@ private[surge] class HealthSignalBusImpl(
   }
 
   override def registrations(matching: Pattern): Future[Seq[SupervisedComponentRegistration]] = {
-    registrations().map(r => r.filter(f => matching.matcher(f.componentName).matches()))(ExecutionContext.global)
+    registrations().map(r => r.filter(f => matching.matcher(f.id.toString).matches()))(ExecutionContext.global)
   }
 
   override def signalWithError(name: String, error: Error, metadata: Map[String, String] = Map.empty): EmittableHealthSignal = {

--- a/modules/common/src/main/scala/surge/internal/health/supervisor/HealthSupervisorActor.scala
+++ b/modules/common/src/main/scala/surge/internal/health/supervisor/HealthSupervisorActor.scala
@@ -173,6 +173,7 @@ class HealthSupervisorActorRef(val actor: ActorRef, askTimeout: FiniteDuration, 
     val result = actor
       .ask(
         RegisterSupervisedComponentRequest(
+          registration.id,
           registration.componentName,
           controlProxy,
           restartSignalPatterns = registration.restartSignalPatterns,
@@ -310,7 +311,7 @@ class HealthSupervisorActor(internalSignalBus: HealthSignalBusInternal, config: 
     case reg: RegisterSupervisedComponentRequest =>
       state.replyTo.foreach(r => r ! HealthRegistrationReceived(reg))
       context.watch(reg.controlProxyRef)
-      context.become(monitoring(state.copy(registered = state.registered + (reg.componentName -> reg.asSupervisedComponentRegistration()))))
+      context.become(monitoring(state.copy(registered = state.registered + (reg.id.toString -> reg.asSupervisedComponentRegistration()))))
       sender() ! Ack()
       getJmxActor.foreach(a => a ! AddComponent(HealthRegistrationDetail(reg.componentName, reg.controlProxyRef.path.toStringWithoutAddress)))
     case remove: UnregisterSupervisedComponentRequest =>


### PR DESCRIPTION
Added the `Id` field in the health supervisor request so that it can be tracked by the `Id`.

Here is the example of the request would look like in the logs

**Health Registration received RegisterSupervisedComponentRequest(b8d09676-2ec6-4e46-8c50-64226f1a2299,kafka-producer-actor-bank-account-state-4,Actor[akka://bank-accountActorSystem/user/$d#360356126],List(),List())**

 **Health Registration received RegisterSupervisedComponentRequest(03661edc-e3db-4501-9e05-a6a7ab9c90cd,persistent-actor-region-bank-account-state-4,Actor[akka://bank-accountActorSystem/user/$d#360356126],List(),List())**
