### PR TITLE
Improvements to OpenTelemetry context propagation

### DIFF
--- a/modules/common/src/main/scala/surge/internal/utils/DiagnosticContextFuturePropagation.scala
+++ b/modules/common/src/main/scala/surge/internal/utils/DiagnosticContextFuturePropagation.scala
@@ -17,12 +17,13 @@ class DiagnosticContextFuturePropagation(executionContext: ExecutionContext) ext
     executionContext.execute(new Runnable {
       def run(): Unit = {
         callerMdc.foreach(MDC.setContextMap)
-        callerSpan.makeCurrent()
+        val scope = callerSpan.makeCurrent()
         try {
           runnable.run()
         } finally {
           // the thread might be reused, so we clean up for the next use
           MDC.clear()
+          scope.close()
         }
       }
     })

--- a/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/AggregateStateStoreKafkaStreams.scala
@@ -114,7 +114,7 @@ class AggregateStateStoreKafkaStreams(
           randomFactor = BackoffConfig.StateStoreKafkaStreamActor.randomFactor)
         .withMaxNrOfRetries(BackoffConfig.StateStoreKafkaStreamActor.maxRetries))
 
-    val underlyingCreatedActor = system.actorOf(aggregateStateStoreKafkaStreamsImplProps)
+    val underlyingCreatedActor = system.actorOf(underlyingActorProps)
 
     system.actorOf(BackoffChildActorTerminationWatcher.props(underlyingCreatedActor, () => onMaxRetries()))
 

--- a/modules/common/src/test/scala/surge/internal/utils/DiagnosticContextFuturePropagationSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/utils/DiagnosticContextFuturePropagationSpec.scala
@@ -35,6 +35,19 @@ class DiagnosticContextFuturePropagationSpec extends AnyFlatSpec with ScalaFutur
     whenReady(futureRequestId) { requestId =>
       requestId mustEqual id
     }
+
+    val doubleFutureRequestId = Future {
+      "something"
+    }.flatMap { _ =>
+      Future {
+        logger.info(s"future requestId propagated: ${MDC.get("requestId")}")
+        MDC.get("requestId")
+      }
+    }
+
+    whenReady(doubleFutureRequestId) { requestId =>
+      requestId mustEqual id
+    }
   }
 
 }

--- a/modules/multilanguage/src/test/scala/com/ukg/surge/multilanguage/MultilanguageGatewayServiceImplSpec.scala
+++ b/modules/multilanguage/src/test/scala/com/ukg/surge/multilanguage/MultilanguageGatewayServiceImplSpec.scala
@@ -18,6 +18,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{ Milliseconds, Seconds, Span }
 import org.scalatest.wordspec.AsyncWordSpecLike
 import play.api.libs.json.Json
+import surge.core.Ack
 import surge.scaladsl.command.SurgeCommand
 
 import java.util.UUID
@@ -40,8 +41,8 @@ class MultilanguageGatewayServiceImplSpec
   }
 
   override def afterAll(): Unit = {
+    testSurgeEngine.stop().futureValue shouldBe an[Ack]
     EmbeddedKafka.stop()
-    testSurgeEngine.stop()
     TestKit.shutdownActorSystem(system)
   }
 


### PR DESCRIPTION
Properly close OpenTelemetry scope when cleaning up resources in `DiagnosticContextFuturePropagation`

Adds a metric `surge.state-store.get-aggregate-state-timer` for time taken to read aggregate state from the KTable (from #147)

Cleans up some timing issues and noise in the multi language tests

Cleans up some timing issues in `SurgeMessagePipelineSpec`