### PR TITLE
Turn case class Ack() to case object

### DIFF
--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -141,7 +141,7 @@ private[surge] final class SurgePartitionRouterImpl(
   }
 
   private[surge] override val controllable: Controllable = new Controllable {
-    override def start(): Future[Ack] = Future.successful(Ack())
+    override def start(): Future[Ack] = Future.successful(Ack)
 
     override def restart(): Future[Ack] = {
       for {
@@ -152,7 +152,7 @@ private[surge] final class SurgePartitionRouterImpl(
       }
     }
 
-    override def stop(): Future[Ack] = Future.successful(Ack())
+    override def stop(): Future[Ack] = Future.successful(Ack)
 
     override def shutdown(): Future[Ack] = stop()
 

--- a/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/domain/SurgeMessagePipeline.scala
@@ -119,13 +119,13 @@ private[surge] abstract class SurgeMessagePipeline[S, M, E](
     log.debug("Starting Health Signal Stream")
     signalStream.start()
 
-    Future.successful[Ack](Ack())
+    Future.successful[Ack](Ack)
   }
 
   private def stopSignalStream(): Future[Ack] = {
     log.debug("Stopping Health Signal Stream")
     signalBus.signalStream().unsubscribe().stop()
-    Future.successful[Ack](Ack())
+    Future.successful[Ack](Ack)
   }
 
   private def unRegistrationCallback(): PartialFunction[Try[Ack], Unit] = {

--- a/modules/command-engine/core/src/multi-jvm/scala/surge/internal/core/SurgePartitionRouterImplMultiJvmSpec.scala
+++ b/modules/command-engine/core/src/multi-jvm/scala/surge/internal/core/SurgePartitionRouterImplMultiJvmSpec.scala
@@ -175,7 +175,7 @@ class SurgePartitionRouterImplSpecBase
     val testContext = createTestContext()
     import testContext._
     "Start router actor successfully" in {
-      partitionRouter.controllable.start().futureValue shouldBe Ack()
+      partitionRouter.controllable.start().futureValue shouldBe Ack
       initializePartitionAssignments(partitionProbe)
     }
 

--- a/modules/command-engine/core/src/test/scala/surge/core/KafkaProducerActorSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/core/KafkaProducerActorSpec.scala
@@ -45,7 +45,7 @@ class KafkaProducerActorSpec
     def producerMock(testProbe: TestProbe): KafkaProducerActor = {
       val signalBus: HealthSignalBusTrait = Mockito.mock(classOf[HealthSignalBusTrait])
       val invokable: InvokableHealthRegistration = Mockito.mock(classOf[InvokableHealthRegistration])
-      when(invokable.invoke()).thenReturn(Future.successful(Ack()))
+      when(invokable.invoke()).thenReturn(Future.successful(Ack))
       when(signalBus.registration(ArgumentMatchers.any(classOf[Controllable]), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(invokable)
       new KafkaProducerActor(ManagedActorRef(testProbe.ref), Metrics.globalMetricRegistry, "test-aggregate-name", new TopicPartition("testTopic", 1), signalBus)

--- a/modules/command-engine/core/src/test/scala/surge/internal/domain/SurgeMessagePipelineSpec.scala
+++ b/modules/command-engine/core/src/test/scala/surge/internal/domain/SurgeMessagePipelineSpec.scala
@@ -215,14 +215,14 @@ class SurgeMessagePipelineSpec
 
       val result = stopped.futureValue
 
-      result shouldEqual Ack()
+      result shouldEqual Ack
     }
 
     "restart successfully" in {
       val restarted = pipeline.controllable.restart()
 
       val result = restarted.futureValue
-      result shouldEqual Ack()
+      result shouldEqual Ack
     }
 
     "shutdown when kafka streams fails to start too many times" in {
@@ -246,8 +246,8 @@ class SurgeMessagePipelineSpec
     }
 
     "unregister all child components after stopping" in {
-      pipeline.controllable.start().futureValue shouldEqual Ack()
-      pipeline.controllable.stop().futureValue shouldEqual Ack()
+      pipeline.controllable.start().futureValue shouldEqual Ack
+      pipeline.controllable.stop().futureValue shouldEqual Ack
 
       eventually {
         pipeline.signalBus.registrations().futureValue shouldBe empty

--- a/modules/common/src/main/scala/surge/core/Controllable.scala
+++ b/modules/common/src/main/scala/surge/core/Controllable.scala
@@ -4,7 +4,8 @@ package surge.core
 
 import scala.concurrent.Future
 
-final case class Ack()
+sealed trait Ack
+case object Ack extends Ack
 
 trait ControllableLookup {
   def lookup(identifier: String): Option[Controllable]
@@ -23,11 +24,11 @@ trait Controllable {
 
 class ControllableAdapter extends Controllable {
 
-  override def start(): Future[Ack] = Future.successful[Ack](Ack())
+  override def start(): Future[Ack] = Future.successful[Ack](Ack)
 
-  override def restart(): Future[Ack] = Future.successful[Ack](Ack())
+  override def restart(): Future[Ack] = Future.successful[Ack](Ack)
 
-  override def stop(): Future[Ack] = Future.successful[Ack](Ack())
+  override def stop(): Future[Ack] = Future.successful[Ack](Ack)
 
-  override def shutdown(): Future[Ack] = Future.successful(Ack())
+  override def shutdown(): Future[Ack] = Future.successful(Ack)
 }

--- a/modules/common/src/main/scala/surge/internal/akka/actor/ActorLifecycleManagerActor.scala
+++ b/modules/common/src/main/scala/surge/internal/akka/actor/ActorLifecycleManagerActor.scala
@@ -81,9 +81,9 @@ class ActorLifecycleManagerActor(
       log.info("Lifecycle manager starting actor named {} for component {}", Seq(actor.prettyPrintPath, componentName): _*)
       context.watch(actor)
       context.become(running(actor))
-      sender() ! Ack()
+      sender() ! Ack
     case ActorLifecycleManagerActor.Stop =>
-      sender() ! Ack()
+      sender() ! Ack
     case ActorLifecycleManagerActor.GetManagedActorPath =>
       sender() ! None
     case msg =>
@@ -94,7 +94,7 @@ class ActorLifecycleManagerActor(
     case ActorLifecycleManagerActor.GetManagedActorPath =>
       sender() ! Some(managedActor.path)
     case ActorLifecycleManagerActor.Start =>
-      sender() ! Ack()
+      sender() ! Ack
     case ActorLifecycleManagerActor.Stop =>
       log.info("Lifecycle manager stopping actor named {} for component {}", Seq(managedActor.prettyPrintPath, componentName): _*)
       stopMessageAdapter match {
@@ -103,7 +103,7 @@ class ActorLifecycleManagerActor(
         case None =>
           gracefulStop(managedActor, defaultStopTimeout)
       }
-      sender() ! Ack()
+      sender() ! Ack
       context.become(stopped)
     case Terminated(actorRef) if actorRef == managedActor =>
       log.info("Lifecycle manager saw actor named {} stop for component {}", Seq(managedActor.prettyPrintPath, componentName): _*)

--- a/modules/common/src/main/scala/surge/internal/health/HealthSignalBus.scala
+++ b/modules/common/src/main/scala/surge/internal/health/HealthSignalBus.scala
@@ -94,7 +94,7 @@ object NoopInvokableHealthRegistration {
 
 private class NoopInvokableHealthRegistration(healthRegistration: HealthRegistration) extends InvokableHealthRegistration {
   override def invoke(): Future[Ack] = {
-    Future.successful[Ack](Ack())
+    Future.successful[Ack](Ack)
   }
 
   override def underlyingRegistration(): HealthRegistration = healthRegistration
@@ -291,7 +291,7 @@ private[surge] class HealthSignalBusImpl(
       case Some(exists) =>
         exists.unregister(componentName)
       case None =>
-        Future.successful(Ack())
+        Future.successful(Ack)
     }
   }
 

--- a/modules/common/src/main/scala/surge/internal/health/supervisor/HealthSupervisorActor.scala
+++ b/modules/common/src/main/scala/surge/internal/health/supervisor/HealthSupervisorActor.scala
@@ -311,11 +311,11 @@ class HealthSupervisorActor(internalSignalBus: HealthSignalBusInternal, config: 
       state.replyTo.foreach(r => r ! HealthRegistrationReceived(reg))
       context.watch(reg.controlProxyRef)
       context.become(monitoring(state.copy(registered = state.registered + (reg.componentName -> reg.asSupervisedComponentRegistration()))))
-      sender() ! Ack()
+      sender() ! Ack
       getJmxActor.foreach(a => a ! AddComponent(HealthRegistrationDetail(reg.componentName, reg.controlProxyRef.path.toStringWithoutAddress)))
     case remove: UnregisterSupervisedComponentRequest =>
       context.become(monitoring(state.copy(registered = state.registered - remove.componentName)))
-      sender() ! Ack()
+      sender() ! Ack
       getJmxActor.foreach(a => a ! RemoveComponent(remove.componentName))
     case HealthRegistrationDetailsRequest() =>
       sender() ! state.registered.values.toList

--- a/modules/common/src/main/scala/surge/kafka/streams/KafkaStreamManagerActor.scala
+++ b/modules/common/src/main/scala/surge/kafka/streams/KafkaStreamManagerActor.scala
@@ -59,11 +59,11 @@ class KafkaStreamManagerActor(surgeConsumer: SurgeStateStoreConsumer, partitionT
   private def stopped: Receive = {
     case Start =>
       start()
-      sender() ! Ack()
+      sender() ! Ack
     case GetHealth =>
       sender() ! getHealth(HealthCheckStatus.DOWN)
     case Stop =>
-      sender() ! Ack()
+      sender() ! Ack
     case KafkaStreamError(t) =>
       handleError(t)
   }
@@ -76,7 +76,7 @@ class KafkaStreamManagerActor(surgeConsumer: SurgeStateStoreConsumer, partitionT
       context.become(running(stream, queryableStore))
     case Stop =>
       stop(stream)
-      sender() ! Ack()
+      sender() ! Ack
     case GetHealth =>
       val status = if (stream.state().isRunningOrRebalancing) HealthCheckStatus.UP else HealthCheckStatus.DOWN
       sender() ! getHealth(status)
@@ -96,9 +96,9 @@ class KafkaStreamManagerActor(surgeConsumer: SurgeStateStoreConsumer, partitionT
       sender() ! getHealth(status)
     case Stop =>
       stop(stream)
-      sender() ! Ack()
+      sender() ! Ack
     case Start =>
-      sender() ! Ack()
+      sender() ! Ack
     case KafkaStreamError(t) =>
       handleError(t)
   }

--- a/modules/common/src/test/scala/surge/internal/akka/actor/ActorLifecycleManagerActorSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/akka/actor/ActorLifecycleManagerActorSpec.scala
@@ -39,7 +39,7 @@ class ActorLifecycleManagerActorSpec
         stopMessageAdapter = Some(() => StopIt),
         componentName = "testComponent")
 
-      managed.start().futureValue shouldEqual Ack()
+      managed.start().futureValue shouldEqual Ack
     }
 
     "gracefully stop actor" in {

--- a/modules/common/src/test/scala/surge/internal/health/supervisor/HealthSupervisorActorSpec.scala
+++ b/modules/common/src/test/scala/surge/internal/health/supervisor/HealthSupervisorActorSpec.scala
@@ -118,7 +118,7 @@ class HealthSupervisorActorSpec
       val control = new ControllableAdapter() {
         override def stop(): Future[Ack] = Future {
           stopProbe.ref ! ShutdownComponent(componentName, probe.ref)
-          Ack()
+          Ack
         }(system.dispatcher)
       }
 
@@ -181,7 +181,7 @@ class HealthSupervisorActorSpec
       val control = new ControllableAdapter() {
         override def restart(): Future[Ack] = Future {
           restartProbe.ref ! RestartComponent(componentName, probe.ref)
-          Ack()
+          Ack
         }(system.dispatcher)
       }
 


### PR DESCRIPTION
This will remove all unneeded object allocations