### PR TITLE
Additionally provide key & header information to event read formatting

### DIFF
--- a/modules/command-engine/scaladsl/src/test/scala/surge/scaladsl/TestBoundedContext.scala
+++ b/modules/command-engine/scaladsl/src/test/scala/surge/scaladsl/TestBoundedContext.scala
@@ -124,8 +124,8 @@ trait TestBoundedContext {
       SerializedMessage(s"${evt.aggregateId}:${evt.sequenceNumber}", Json.toJson(evt).toString().getBytes())
     }
 
-    override def readEvent(bytes: Array[Byte]): BaseTestEvent = {
-      Json.parse(bytes).as[BaseTestEvent]
+    override def readEvent(serialized: SerializedMessage): BaseTestEvent = {
+      Json.parse(serialized.value).as[BaseTestEvent]
     }
   }
 

--- a/modules/serialization/src/main/scala/surge/core/SurgeFormatting.scala
+++ b/modules/serialization/src/main/scala/surge/core/SurgeFormatting.scala
@@ -3,7 +3,7 @@
 package surge.core
 
 trait SurgeEventReadFormatting[Event] {
-  def readEvent(bytes: Array[Byte]): Event
+  def readEvent(serialized: SerializedMessage): Event
 }
 
 trait SurgeAggregateReadFormatting[State] {


### PR DESCRIPTION
Some deserialization would benefit from having the additional context of the key and headers passed through the deserialization, for example verifying an authorization header or extracting other context from the message headers that isn't present in the message body.