### PR TITLE
Add readiness healthcheck to surge engine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ lazy val `surge-common` = (project in file("modules/common"))
       Akka.clusterSharding,
       Akka.kafkaStream,
       Akka.kafkaStreamTestKit,
+      Akka.management,
+      Akka.managementClusterBootstrap,
       Kafka.kafkaClients,
       Kafka.kafkaStreams,
       Kafka.kafkaStreamsScala,

--- a/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
+++ b/modules/command-engine/core/src/main/scala/surge/internal/core/SurgePartitionRouterImpl.scala
@@ -29,7 +29,8 @@ import java.util.regex.Pattern
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.jdk.CollectionConverters._
-import scala.languageFeature.postfixOps
+import akka.management.HealthCheckSettings
+import akka.management.scaladsl.HealthChecks
 
 private[surge] final class SurgePartitionRouterImpl(
     config: Config,
@@ -44,6 +45,10 @@ private[surge] final class SurgePartitionRouterImpl(
     extends SurgePartitionRouter
     with HealthyComponent {
   private val log = LoggerFactory.getLogger(getClass)
+
+  private val settings: HealthCheckSettings = HealthCheckSettings(system.settings.config.getConfig("akka.management.health-checks"))
+
+  private val healthChecks = HealthChecks(system.asInstanceOf[ExtendedActorSystem], settings)
 
   override val actorRegion: ActorRef = {
     if (isAkkaClusterEnabled) {
@@ -119,6 +124,11 @@ private[surge] final class SurgePartitionRouterImpl(
   }
 
   override def restartSignalPatterns(): Seq[Pattern] = Seq(Pattern.compile("kafka.fatal.error"))
+
+  override def ready(): Future[HealthCheck] = for {
+    ready <- healthChecks.ready()
+    status = if (ready) HealthCheckStatus.UP else HealthCheckStatus.DOWN
+  } yield HealthCheck(name = "router-actor", id = s"router-actor-${actorRegion.hashCode}", status)
 
   override def healthCheck(): Future[HealthCheck] = {
     if (isAkkaClusterEnabled) {

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommand.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/command/SurgeCommand.scala
@@ -84,6 +84,10 @@ private[javadsl] class SurgeCommandImpl[AggId, Agg, Command, Evt](
     FutureConverters.toJava(healthCheck().map(_.asJava))
   }
 
+  def getReady: CompletionStage[HealthCheck] = {
+    FutureConverters.toJava(ready().map(_.asJava))
+  }
+
   def aggregateFor(aggregateId: AggId): AggregateRef[Agg, Command, Evt] = {
     new AggregateRefImpl(aggIdToString(aggregateId), actorRouter.actorRegion, businessLogic.tracer, getEngineStatus)
   }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/common/HealthCheckTrait.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/common/HealthCheckTrait.scala
@@ -7,4 +7,5 @@ import java.util.concurrent.CompletionStage
 
 trait HealthCheckTrait {
   def getHealthCheck: CompletionStage[HealthCheck]
+  def getReady: CompletionStage[HealthCheck]
 }

--- a/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/SurgeEvent.scala
+++ b/modules/command-engine/javadsl/src/main/scala/surge/javadsl/event/SurgeEvent.scala
@@ -61,6 +61,10 @@ private[javadsl] class SurgeEventImpl[AggId, Agg, Evt](
     FutureConverters.toJava(healthCheck().map(_.asJava))
   }
 
+  def getReady: CompletionStage[HealthCheck] = {
+    FutureConverters.toJava(ready().map(_.asJava))
+  }
+
   def aggregateFor(aggregateId: AggId): AggregateRef[Agg, Evt] = {
     new AggregateRefImpl(aggIdToString(aggregateId), actorRouter.actorRegion, businessLogic.tracer)
   }

--- a/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/common/HealthCheckTrait.scala
+++ b/modules/command-engine/scaladsl/src/main/scala/surge/scaladsl/common/HealthCheckTrait.scala
@@ -9,4 +9,5 @@ import scala.concurrent.Future
 
 trait HealthCheckTrait {
   def healthCheck: Future[HealthCheck]
+  def ready: Future[HealthCheck]
 }

--- a/modules/common/src/main/scala/surge/internal/health/SurgeHealthCheck.scala
+++ b/modules/common/src/main/scala/surge/internal/health/SurgeHealthCheck.scala
@@ -57,6 +57,13 @@ trait HealthyComponent {
   def healthCheck(): Future[HealthCheck]
 
   /**
+   * Perform a readiness check
+   * @return
+   *   HealthCheck
+   */
+  def ready(): Future[HealthCheck] = Future.successful(HealthCheck(name = "NA", id = "NA", status = HealthCheckStatus.UP))
+
+  /**
    * Signals Patterns that will trigger a restart
    * @return
    *   Seq[Pattern]


### PR DESCRIPTION
for https://github.com/UltimateSoftware/surge-ukg/pull/473

Adds a readiness healthcheck to surge engine, as a method `def ready(): Future[HealthCheck]` in the HealthCheckTrait trait,
and it delegates to akka management, without starting an AM http server.
Liveness check is already implemented in the existing `healthCheck()` method.